### PR TITLE
Glue Traits between Types and Requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "A client for the Elassticsearch REST API."
@@ -15,7 +15,9 @@ reqwest = "~0.2.0"
 elastic_reqwest = "~0.1.0"
 elastic_requests = "~0.1.0"
 elastic_responses = "~0.2.0"
-elastic_types = "~0.9.0"
+elastic_types = { version = "~0.10.0", path = "../elastic-types/types" }
 
 [dev-dependencies]
 json_str = "~0.3.0"
+serde_derive = "~0.8.0"
+elastic_types_derive = { version = "~0.9.0", path = "../elastic-types/macros/types", features = ["elastic"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,14 @@ documentation = "https://docs.rs/elastic/"
 repository = "https://github.com/elastic-rs/elastic"
 
 [dependencies]
-elastic_types = "~0.9.0"
-elastic_requests = "~0.1.0"
+serde = "~0.8.0"
+serde_json = "~0.8.0"
 reqwest = "~0.2.0"
+
 elastic_reqwest = "~0.1.0"
+elastic_requests = "~0.1.0"
 elastic_responses = "~0.2.0"
+elastic_types = "~0.9.0"
 
 [dev-dependencies]
 json_str = "~0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = "~0.8.0"
 serde_json = "~0.8.0"
 reqwest = "~0.2.0"
 
-elastic_reqwest = { version = "~0.2.0", path = "../elastic-hyper" }
+elastic_reqwest = "~0.2.0"
 elastic_requests = "~0.1.0"
 elastic_responses = "~0.2.0"
 elastic_types = "~0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ reqwest = "~0.2.0"
 elastic_reqwest = "~0.1.0"
 elastic_requests = "~0.1.0"
 elastic_responses = "~0.2.0"
-elastic_types = { version = "~0.10.0", path = "../elastic-types/types" }
+elastic_types = "~0.10.0"
 
 [dev-dependencies]
 json_str = "~0.3.0"
 serde_derive = "~0.8.0"
-elastic_types_derive = { version = "~0.9.0", path = "../elastic-types/macros/types", features = ["elastic"] }
+elastic_types_derive = { version = "~0.9.0", features = ["elastic"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,18 @@ description = "A client for the Elassticsearch REST API."
 documentation = "https://docs.rs/elastic/"
 repository = "https://github.com/elastic-rs/elastic"
 
+[features]
+nightly = [
+	"elastic_types/nightly" 
+]
+
 [dependencies]
 error-chain = "~0.7.0"
 serde = "~0.8.0"
 serde_json = "~0.8.0"
 reqwest = "~0.2.0"
 
-elastic_reqwest = "~0.1.0"
+elastic_reqwest = { version = "~0.2.0", path = "../elastic-hyper" }
 elastic_requests = "~0.1.0"
 elastic_responses = "~0.2.0"
 elastic_types = "~0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ documentation = "https://docs.rs/elastic/"
 repository = "https://github.com/elastic-rs/elastic"
 
 [dependencies]
+error-chain = "~0.7.0"
 serde = "~0.8.0"
 serde_json = "~0.8.0"
 reqwest = "~0.2.0"
@@ -15,9 +16,9 @@ reqwest = "~0.2.0"
 elastic_reqwest = "~0.1.0"
 elastic_requests = "~0.1.0"
 elastic_responses = "~0.2.0"
-elastic_types = "~0.10.0"
+elastic_types = "~0.10.1"
 
 [dev-dependencies]
 json_str = "~0.3.0"
 serde_derive = "~0.8.0"
-elastic_types_derive = { version = "~0.9.0", features = ["elastic"] }
+elastic_types_derive = { version = "~0.10.0", features = ["elastic"] }

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -21,19 +21,24 @@ struct MyType {
 }
 
 fn main() {
-    // A reqwest HTTP client and default parameters.
-    // The `params` includes the base node url (http://localhost:9200).
-    let (client, params) = client::default().unwrap();
+    // A reqwest HTTP client.
+    let client = client::Client::new().unwrap();
 
+    // The `params` includes the base node url (http://localhost:9200).
+    let params = client::RequestParams::default()
+        .url_params(vec![("refresh", String::from("true"))]);
+
+    // The document to index
     let doc = MyType {
         id: 1,
         title: String::from("A title")
     };
 
     let index = client::Index::from("typed_sample_index");
+    let id = client::Id::from(doc.id.to_string());
 
     // An index request
-    let req = client::IndexRequest::from_doc((index.clone(), &doc)).unwrap();
+    let req = client::IndexRequest::try_for_doc((index.clone(), id, &doc)).unwrap();
 
     // Response from the index
     client.elastic_req(&params, req).unwrap();

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -1,0 +1,63 @@
+//! A basic typed example.
+//! 
+//! NOTE: This sample expects you have a node running on `localhost:9200`.
+
+#[macro_use]
+extern crate json_str;
+#[macro_use]
+extern crate elastic_types_derive;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+
+extern crate elastic;
+
+use elastic::types::prelude::FieldType;
+use elastic::client::{self, ElasticClient, FromDoc};
+
+#[derive(Debug, Serialize, Deserialize, ElasticType)]
+struct MyType {
+    id: i32,
+    title: String
+}
+
+fn main() {
+    // A reqwest HTTP client and default parameters.
+    // The `params` includes the base node url (http://localhost:9200).
+    let (client, params) = client::default().unwrap();
+
+    let doc = MyType {
+        id: 1,
+        title: String::from("A title")
+    };
+
+    let index = client::Index::from("typed_sample_index");
+
+    // An index request
+    let req = client::IndexRequest::from_doc((index.clone(), &doc));
+
+    // Response from the index
+    client.elastic_req(&params, req).unwrap();
+
+    // A freeform JSON request body.
+    let body = json_str!({
+        query: {
+            query_string: {
+                query: "*"
+            }
+        }
+    });
+
+    // A search request from the body.
+    let req = client::SearchRequest::for_index(index, body);
+
+    // Send the request and process the response.
+    let res: client::ResponseOf<MyType> = client
+        .elastic_req(&params, req).unwrap()
+        .json().unwrap();
+
+    // Iterate through the hits in the response.
+    for hit in res.hits() {
+        println!("{:?}", hit);
+    }
+}

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -12,7 +12,6 @@ extern crate serde;
 
 extern crate elastic;
 
-use elastic::types::prelude::FieldType;
 use elastic::client::{self, ElasticClient, FromDoc};
 
 #[derive(Debug, Serialize, Deserialize, ElasticType)]
@@ -34,7 +33,7 @@ fn main() {
     let index = client::Index::from("typed_sample_index");
 
     // An index request
-    let req = client::IndexRequest::from_doc((index.clone(), &doc));
+    let req = client::IndexRequest::from_doc((index.clone(), &doc)).unwrap();
 
     // Response from the index
     client.elastic_req(&params, req).unwrap();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,9 @@
+use serde_json::Error as JsonError;
+use reqwest::Error as HttpError;
+
+error_chain! {
+    foreign_links {
+        Json(JsonError);
+        Http(HttpError);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,84 +33,64 @@ pub mod client {
     pub use elastic_responses::*;
 
     use serde_json;
-    use serde::Serialize;
 
     use super::errors::*;
     use super::types::prelude::{FieldType, Document, DocumentType, DocumentMapping};
 
-    /// A trait for converting a serialisable type into a request.
-    pub trait FromType<T>: Sized {
-        fn try_for_ty(ty: T) -> Result<Self>;
-    }
-
     /// A trait for converting a document into a request.
-    pub trait FromDoc<T, M>: Sized {
+    pub trait TryForDoc<T, M>: Sized {
         fn try_for_doc(doc: T) -> Result<Self>;
     }
 
     /// A trait for converting a document mapping into a request.
-    pub trait FromMapping<M>: Sized {
+    pub trait TryForMapping<M> 
+        where Self: Sized
+    {
         fn try_for_mapping(mapping: M) -> Result<Self>;
     }
 
-    impl<'a, 'b, IDoc> FromType<(Index<'a>, Type<'a>, &'b IDoc)> for IndexRequest<'a>
-        where IDoc: Serialize
+    impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndexRequest<'a>
+        where T: DocumentType<M>,
+              M: DocumentMapping
     {
-        fn try_for_ty((index, ty, doc): (Index<'a>, Type<'a>, &'b IDoc)) -> Result<Self> {
+        fn try_for_doc((index, doc): (Index<'a>, &'b T)) -> Result<Self> {
+            let ty = T::name();
+
             let doc = serde_json::to_string(&doc)?;
 
             Ok(Self::for_index_ty(index, ty, doc))
         }
     }
 
-    impl<'a, 'b, IDoc> FromType<(Index<'a>, Type<'a>, Id<'a>, &'b IDoc)> for IndexRequest<'a>
-        where IDoc: Serialize
+    impl<'a, 'b, T, M> TryForDoc<(Index<'a>, Id<'a>, &'b T), M> for IndexRequest<'a>
+        where T: DocumentType<M>,
+              M: DocumentMapping
     {
-        fn try_for_ty((index, ty, id, doc): (Index<'a>, Type<'a>, Id<'a>, &'b IDoc)) -> Result<Self> {
+        fn try_for_doc((index, id, doc): (Index<'a>, Id<'a>, &'b T)) -> Result<Self> {
+            let ty = T::name();
+
             let doc = serde_json::to_string(&doc)?;
 
             Ok(Self::for_index_ty_id(index, ty, id, doc))
         }
     }
 
-    impl<'a, 'b, IDoc, IMapping> FromDoc<(Index<'a>, &'b IDoc), IMapping> for IndexRequest<'a>
-        where IDoc: DocumentType<IMapping>,
-              IMapping: DocumentMapping
+    impl<'a, M> TryForMapping<(Index<'a>, M)> for IndicesPutMappingRequest<'a>
+        where M: DocumentMapping
     {
-        fn try_for_doc((index, doc): (Index<'a>, &'b IDoc)) -> Result<Self> {
-            let ty = IDoc::name();
-
-            Self::try_for_ty((index, Type::from(ty), doc))
-        }
-    }
-
-    impl<'a, 'b, IDoc, IMapping> FromDoc<(Index<'a>, Id<'a>, &'b IDoc), IMapping> for IndexRequest<'a>
-        where IDoc: DocumentType<IMapping>,
-              IMapping: DocumentMapping
-    {
-        fn try_for_doc((index, id, doc): (Index<'a>, Id<'a>, &'b IDoc)) -> Result<Self> {
-            let ty = IDoc::name();
-
-            Self::try_for_ty((index, Type::from(ty), id, doc))
-        }
-    }
-
-    impl<'a, IMapping> FromMapping<(Index<'a>, IMapping)> for IndicesPutMappingRequest<'a>
-        where IMapping: DocumentMapping
-    {
-        fn try_for_mapping((index, mapping): (Index<'a>, IMapping)) -> Result<Self> {
+        fn try_for_mapping((index, mapping): (Index<'a>, M)) -> Result<Self> {
             let mapping = serde_json::to_string(&Document::from(mapping))?;
 
-            Ok(Self::for_index_ty(index, IMapping::name(), mapping))
+            Ok(Self::for_index_ty(index, M::name(), mapping))
         }
     }
 
-    impl <'a, 'b, IDoc, IMapping> FromDoc<(Index<'a>, &'b IDoc), IMapping> for IndicesPutMappingRequest<'a>
-        where IDoc: DocumentType<IMapping>,
-              IMapping: DocumentMapping
+    impl <'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndicesPutMappingRequest<'a>
+        where T: DocumentType<M>,
+              M: DocumentMapping
     {
-        fn try_for_doc((index, _): (Index<'a>, &'b IDoc)) -> Result<Self> {
-            Self::try_for_mapping((index, IDoc::mapping()))
+        fn try_for_doc((index, _): (Index<'a>, &'b T)) -> Result<Self> {
+            Self::try_for_mapping((index, T::mapping()))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate is a meta-package that makes it easy to work
 //! with the Elasticsearch REST API.
 
+extern crate serde;
+extern crate serde_json;
 extern crate reqwest;
 extern crate elastic_reqwest;
 extern crate elastic_requests;
@@ -25,6 +27,85 @@ pub mod client {
 
     /// Response types for the Elasticsearch REST API.
     pub use elastic_responses::*;
+
+    use serde_json;
+    use serde::Serialize;
+    use super::types::prelude::{ FieldType, Document, DocumentType, DocumentMapping };
+
+    /// A trait for converting a serialisable type into a request.
+    pub trait FromType<'a, IDoc>
+        where IDoc: Serialize 
+    {
+        // TODO: Support an Id
+        //      May need to use builders for this
+        // TODO: Return Result<Self, Error>
+        fn from_ty<IIndex, IType>(index: IIndex, ty: IType, doc: &IDoc) -> Self
+            where IIndex: Into<Index<'a>>,
+                  IType: Into<Type<'a>>;
+    }
+
+    /// A trait for converting a document into a request.
+    pub trait FromDoc<'a, IDoc, IMapping> {
+        // TODO: Return Result<Self, Error>
+        fn from_doc<IIndex>(index: IIndex, doc: &IDoc) -> Self
+            where IIndex: Into<Index<'a>>;
+    }
+
+    /// A trait for converting a document mapping into a request.
+    pub trait FromMapping<'a, IMapping> {
+        // TODO: Return Result<Self, Error>
+        fn from_mapping<IIndex>(index: IIndex, mapping: IMapping) -> Self
+            where IIndex: Into<Index<'a>>;
+    }
+
+    impl <'a, IDoc> FromType<'a, IDoc> for IndexRequest<'a>
+        where IDoc: Serialize 
+    {
+        fn from_ty<IIndex, IType>(index: IIndex, ty: IType, doc: &IDoc) -> Self
+            where IIndex: Into<Index<'a>>,
+                  IType: Into<Type<'a>>
+        {
+            let doc = serde_json::to_string(&doc).unwrap();
+
+            Self::for_index_ty(index, ty, doc)
+        }
+    }
+
+    impl <'a, IDoc, IMapping> FromDoc<'a, IDoc, IMapping> for IndexRequest<'a>
+        where IDoc: DocumentType<IMapping>, 
+              IMapping: DocumentMapping
+    {
+        fn from_doc<IIndex>(index: IIndex, doc: &IDoc) -> Self
+            where IIndex: Into<Index<'a>> 
+        {
+            let ty = IDoc::name();
+
+            Self::from_ty(index, ty, doc)
+        }
+    }
+
+    impl <'a, IMapping> FromMapping<'a, IMapping> for IndicesPutMappingRequest<'a>
+        where IMapping: DocumentMapping
+    {
+        fn from_mapping<IIndex>(index: IIndex, mapping: IMapping) -> Self
+            where IIndex: Into<Index<'a>>
+        {
+            let mapping = serde_json::to_string(&Document::from(mapping)).unwrap();
+
+            Self::for_index_ty(index, IMapping::name(), mapping)
+        }
+    }
+
+    impl <'a, IDoc, IMapping> FromDoc<'a, IDoc, IMapping> for IndicesPutMappingRequest<'a>
+        where IDoc: DocumentType<IMapping>, 
+              IMapping: DocumentMapping
+    {
+        fn from_doc<IIndex>(index: IIndex, _: &IDoc) -> Self
+            where IIndex: Into<Index<'a>> 
+        {
+            Self::from_mapping(index, IDoc::mapping())
+        }
+    }
 }
 
 pub mod types {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod client {
     /// Response types for the Elasticsearch REST API.
     pub use elastic_responses::*;
 
+    use serde::Serialize;
     use serde_json;
 
     use super::errors::*;
@@ -72,6 +73,16 @@ pub mod client {
             let doc = serde_json::to_string(&doc)?;
 
             Ok(Self::for_index_ty_id(index, ty, id, doc))
+        }
+    }
+
+    impl<'a, T> TryForDoc<(Index<'a>, T), ()> for IndicesCreateRequest<'a>
+        where T: Serialize
+    {
+        fn try_for_doc((index, doc): (Index<'a>, T)) -> Result<Self> {
+            let doc = serde_json::to_string(&doc)?;
+
+            Ok(Self::for_index(index, doc))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod client {
     //! This module contains the core `ElasticClient` trait, as well
     //! as request and response types.
 
-    pub use reqwest::Client;
+    pub use reqwest::{Client, Response as HttpResponse, StatusCode};
 
     /// A client wrapper over [`reqwest`](https://github.com/seanmonstar/reqwest).
     pub use elastic_reqwest::*;
@@ -76,13 +76,13 @@ pub mod client {
         }
     }
 
-    impl<'a, T> TryForDoc<(Index<'a>, T), ()> for IndicesCreateRequest<'a>
+    impl<'a, 'b, T> TryForDoc<&'b T, ()> for Body<'a>
         where T: Serialize
     {
-        fn try_for_doc((index, doc): (Index<'a>, T)) -> Result<Self> {
+        fn try_for_doc(doc: &T) -> Result<Self> {
             let doc = serde_json::to_string(&doc)?;
 
-            Ok(Self::for_index(index, doc))
+            Ok(Self::from(doc))
         }
     }
 
@@ -113,4 +113,9 @@ pub mod types {
     //! document types.
 
     pub use elastic_types::*;
+}
+
+pub mod prelude {
+    pub use super::client::*;
+    pub use super::types::prelude::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,31 +40,36 @@ pub mod client {
 
     /// A trait for converting a serialisable type into a request.
     pub trait FromType<T>: Sized {
-        // TODO: Support an Id
-        //      May need to use builders for this
-        // TODO: Return Result<Self, Error>
-        fn from_ty(ty: T) -> Result<Self>;
+        fn try_for_ty(ty: T) -> Result<Self>;
     }
 
     /// A trait for converting a document into a request.
     pub trait FromDoc<T, M>: Sized {
-        // TODO: Return Result<Self, Error>
-        fn from_doc(doc: T) -> Result<Self>;
+        fn try_for_doc(doc: T) -> Result<Self>;
     }
 
     /// A trait for converting a document mapping into a request.
     pub trait FromMapping<M>: Sized {
-        // TODO: Return Result<Self, Error>
-        fn from_mapping(mapping: M) -> Result<Self>;
+        fn try_for_mapping(mapping: M) -> Result<Self>;
     }
 
     impl<'a, 'b, IDoc> FromType<(Index<'a>, Type<'a>, &'b IDoc)> for IndexRequest<'a>
         where IDoc: Serialize
     {
-        fn from_ty((index, ty, doc): (Index<'a>, Type<'a>, &'b IDoc)) -> Result<Self> {
+        fn try_for_ty((index, ty, doc): (Index<'a>, Type<'a>, &'b IDoc)) -> Result<Self> {
             let doc = serde_json::to_string(&doc)?;
 
             Ok(Self::for_index_ty(index, ty, doc))
+        }
+    }
+
+    impl<'a, 'b, IDoc> FromType<(Index<'a>, Type<'a>, Id<'a>, &'b IDoc)> for IndexRequest<'a>
+        where IDoc: Serialize
+    {
+        fn try_for_ty((index, ty, id, doc): (Index<'a>, Type<'a>, Id<'a>, &'b IDoc)) -> Result<Self> {
+            let doc = serde_json::to_string(&doc)?;
+
+            Ok(Self::for_index_ty_id(index, ty, id, doc))
         }
     }
 
@@ -72,17 +77,28 @@ pub mod client {
         where IDoc: DocumentType<IMapping>,
               IMapping: DocumentMapping
     {
-        fn from_doc((index, doc): (Index<'a>, &'b IDoc)) -> Result<Self> {
+        fn try_for_doc((index, doc): (Index<'a>, &'b IDoc)) -> Result<Self> {
             let ty = IDoc::name();
 
-            Self::from_ty((index, Type::from(ty), doc))
+            Self::try_for_ty((index, Type::from(ty), doc))
+        }
+    }
+
+    impl<'a, 'b, IDoc, IMapping> FromDoc<(Index<'a>, Id<'a>, &'b IDoc), IMapping> for IndexRequest<'a>
+        where IDoc: DocumentType<IMapping>,
+              IMapping: DocumentMapping
+    {
+        fn try_for_doc((index, id, doc): (Index<'a>, Id<'a>, &'b IDoc)) -> Result<Self> {
+            let ty = IDoc::name();
+
+            Self::try_for_ty((index, Type::from(ty), id, doc))
         }
     }
 
     impl<'a, IMapping> FromMapping<(Index<'a>, IMapping)> for IndicesPutMappingRequest<'a>
         where IMapping: DocumentMapping
     {
-        fn from_mapping((index, mapping): (Index<'a>, IMapping)) -> Result<Self> {
+        fn try_for_mapping((index, mapping): (Index<'a>, IMapping)) -> Result<Self> {
             let mapping = serde_json::to_string(&Document::from(mapping))?;
 
             Ok(Self::for_index_ty(index, IMapping::name(), mapping))
@@ -93,9 +109,8 @@ pub mod client {
         where IDoc: DocumentType<IMapping>,
               IMapping: DocumentMapping
     {
-        fn from_doc((index, _): (Index<'a>, &'b IDoc)) -> Result<Self>
-        {
-            Self::from_mapping((index, IDoc::mapping()))
+        fn try_for_doc((index, _): (Index<'a>, &'b IDoc)) -> Result<Self> {
+            Self::try_for_mapping((index, IDoc::mapping()))
         }
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -25,5 +25,5 @@ fn index_request_from_doc() {
 
     let req = client::IndexRequest::from_doc((index, &doc));
 
-    //assert!(req.is_ok());
+    assert!(req.is_ok());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -6,7 +6,6 @@ extern crate serde;
 extern crate elastic;
 
 use elastic::client::{self, FromDoc};
-use elastic::types::prelude::*;
 
 #[derive(Serialize, ElasticType)]
 struct MyType {
@@ -23,7 +22,7 @@ fn index_request_from_doc() {
 
     let index = client::Index::from("test_index");
 
-    let req = client::IndexRequest::from_doc((index, &doc));
+    let req = client::IndexRequest::try_for_doc((index, &doc));
 
     assert!(req.is_ok());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate elastic_types_derive;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate json_str;
+
+extern crate serde;
+extern crate serde_json;
+extern crate elastic;
+
+use elastic::client::*;
+use elastic::types::prelude::*;
+
+#[derive(Serialize, ElasticType)]
+struct MyType {
+	id: i32,
+	title: &'static str
+}
+
+#[test]
+fn index_request_from_doc() {
+	let doc = MyType {
+		id: 1,
+		title: "A title"
+	};
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,14 +2,11 @@
 extern crate elastic_types_derive;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate json_str;
 
 extern crate serde;
-extern crate serde_json;
 extern crate elastic;
 
-use elastic::client::*;
+use elastic::client::{self, FromDoc};
 use elastic::types::prelude::*;
 
 #[derive(Serialize, ElasticType)]
@@ -25,7 +22,7 @@ fn index_request_from_doc() {
         title: "A title"
     };
 
-    let index = Index::from("test_index");
+    let index = client::Index::from("test_index");
 
-    let req = IndexRequest::from_doc((index, &doc));
+    let req = client::IndexRequest::from_doc((index, &doc));
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,7 +2,6 @@
 extern crate elastic_types_derive;
 #[macro_use]
 extern crate serde_derive;
-
 extern crate serde;
 extern crate elastic;
 
@@ -25,4 +24,6 @@ fn index_request_from_doc() {
     let index = client::Index::from("test_index");
 
     let req = client::IndexRequest::from_doc((index, &doc));
+
+    //assert!(req.is_ok());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -14,14 +14,18 @@ use elastic::types::prelude::*;
 
 #[derive(Serialize, ElasticType)]
 struct MyType {
-	id: i32,
-	title: &'static str
+    id: i32,
+    title: &'static str
 }
 
 #[test]
 fn index_request_from_doc() {
-	let doc = MyType {
-		id: 1,
-		title: "A title"
-	};
+    let doc = MyType {
+        id: 1,
+        title: "A title"
+    };
+
+    let index = Index::from("test_index");
+
+    let req = IndexRequest::from_doc((index, &doc));
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -5,7 +5,7 @@ extern crate serde_derive;
 extern crate serde;
 extern crate elastic;
 
-use elastic::client::{self, FromDoc};
+use elastic::client::{self, TryForDoc};
 
 #[derive(Serialize, ElasticType)]
 struct MyType {


### PR DESCRIPTION
Part of #153 

This aims to add some traits that make it easy to build request types in `elastic_requests` from document types in `elastic_types`. It's a first pass so is a bit raw.

I'm not convinced the definitions so far are any good. Mostly because the trait methods are trying to cover the whole parameter surface when they shouldn't. It'd be better to take a `self` argument so builders can be supported in the future.

That way they don't need to cover everything, and additional parameters can be provided by tuples (this is ok because we've got type wrappers for each one, `(Type::from("ty"), Id::from("1"))` is not the same as `(Id::from("1"), Type::from("ty"))`. We could also offer bespoke builders that can be used to construct requests.

# TODO

- [x] Add `PutIndicesMappingRequest` example using `from_doc`
- [x] Add error chain for `serde_json::Error` and `reqwest::Error`
- [ ] Sort https://github.com/stephanbuys/elastic-responses/issues/6
- [x] Sort https://github.com/elastic-rs/elastic-types/issues/45