### PR TITLE
Add a Http Client wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "elastic"
 version = "0.3.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
-description = "A client for the Elassticsearch REST API."
+description = "A client for the Elasticsearch REST API."
 documentation = "https://docs.rs/elastic/"
 repository = "https://github.com/elastic-rs/elastic"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ elastic_responses = "~0.2.0"
 elastic_types = "~0.10.1"
 
 [dev-dependencies]
-json_str = "~0.3.0"
+json_str = "^0.*"
 serde_derive = "~0.8.0"
 elastic_types_derive = { version = "~0.10.0", features = ["elastic"] }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ elastic = "*"
 json_str = "*"
 ```
 
-Get a client instance and request parameters:
+And reference in your crate root:
 
 ```rust
 #[macro_use]
@@ -65,8 +65,12 @@ extern crate json_str;
 extern crate elastic;
 
 use elastic::client;
+```
 
-let (client, params) = client::default().unwrap();
+Get a client instance:
+
+```rust
+let client = Client::new(RequestParams::default()).unwrap();
 ```
 
 Create a search request:
@@ -87,8 +91,10 @@ Send the request and iterate through the returned hits:
 
 ```rust
 let res: client::Response = client
-    .elastic_req(&params, req).unwrap()
-    .json().unwrap();
+    .request(req)
+    .send()
+    .and_then(|res| res.json())
+    .unwrap();
 
 for hit in res.hits() {
     println!("{:?}", hit);

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,12 +6,13 @@
 extern crate json_str;
 extern crate elastic;
 
-use elastic::client::{self, ElasticClient};
+use elastic::prelude::*;
 
 fn main() {
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
-    let (client, params) = client::default().unwrap();
+    let client = Client::new().unwrap();
+    let params = RequestParams::default();
 
     // A freeform JSON request body.
     let body = json_str!({
@@ -23,12 +24,13 @@ fn main() {
     });
 
     // A search request from the body.
-    let req = client::SearchRequest::for_index("_all", body);
+    let req = SearchRequest::for_index("_all", body);
 
     // Send the request and process the response.
-    let res: client::Response = client
-        .elastic_req(&params, req).unwrap()
-        .json().unwrap();
+    let res: Response = client
+        .request(&params, req)
+        .and_then(|res| res.json())
+        .unwrap();
 
     // Iterate through the hits in the response.
     for hit in res.hits() {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,8 +11,7 @@ use elastic::prelude::*;
 fn main() {
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
-    let client = Client::new().unwrap();
-    let params = RequestParams::default();
+    let client = Client::new(RequestParams::default()).unwrap();
 
     // A freeform JSON request body.
     let body = json_str!({
@@ -28,7 +27,8 @@ fn main() {
 
     // Send the request and process the response.
     let res: Response = client
-        .request(&params, req)
+        .request(req)
+        .send()
         .and_then(|res| res.json())
         .unwrap();
 

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -24,31 +24,79 @@ struct MyType {
     timestamp: Date<DefaultDateFormat>
 }
 
-fn index_exists() -> IndicesExistsRequest<'static> {
+fn main() {
+    // A HTTP client and request parameters
+    let client = Client::new().unwrap();
+    let params = RequestParams::default();
+
+    // Create a document to index
+    let doc = MyType {
+        id: 1,
+        title: String::from("A title"),
+        timestamp: Date::now()
+    };
+
+    create_index_if_new(&client, &params);
+
+    index_doc(&client, &params, doc);
+
+    let res = search_docs(&client, &params);
+
+    println!("{:?}", res);
+}
+
+// Create the index if it doesn't already exist
+fn index_exists_request() -> IndicesExistsRequest<'static> {
     let index = Index::from(INDEX);
 
     IndicesExistsRequest::for_index(index)
 }
 
-fn put_index() -> IndicesCreateRequest<'static> {
+fn put_index_request() -> IndicesCreateRequest<'static> {
     let index = Index::from(INDEX);
 
     IndicesCreateRequest::for_index(index, Body::none())
 }
 
-fn map_doc(doc: &MyType) -> IndicesPutMappingRequest<'static> {
+fn create_index_if_new(client: &Client, params: &RequestParams) {
+    let exists = client.request(&params, index_exists_request())
+        .and_then(|res| {
+            match *res.raw().status() {
+                StatusCode::NotFound => Ok(false),
+                _ => Ok(true)
+            }
+        })
+        .unwrap();
+
+    if !exists {
+        client.request(&params, put_index_request()).unwrap();
+    }
+}
+
+// Update the document mapping and index our document
+fn map_doc_request(doc: &MyType) -> IndicesPutMappingRequest<'static> {
     let index = Index::from(INDEX);
 
     IndicesPutMappingRequest::try_for_doc((index, doc)).unwrap()
 }
 
-fn put_doc(doc: &MyType) -> IndexRequest<'static> {
+fn put_doc_request(doc: &MyType) -> IndexRequest<'static> {
     let index = Index::from(INDEX);
     let id = Id::from(doc.id.to_string());
 
     IndexRequest::try_for_doc((index, id, doc)).unwrap()
 }
 
+fn index_doc(client: &Client, params: &RequestParams, doc: MyType) {
+    client.request(&params, map_doc_request(&doc)).unwrap();
+
+    // Wait for refresh when indexing so we can search right away
+    let params = params.clone().url_param("refresh", true);
+
+    client.request(&params, put_doc_request(&doc)).unwrap();
+}
+
+// Search for documents in the index
 fn search() -> SearchRequest<'static> {
     let index = Index::from(INDEX);
 
@@ -63,40 +111,6 @@ fn search() -> SearchRequest<'static> {
     SearchRequest::for_index(index, body)
 }
 
-fn main() {
-    // A reqwest HTTP client.
-    let client = Client::new().unwrap();
-
-    // The `params` includes the base node url (http://localhost:9200).
-    let params = RequestParams::default();
-
-    // Wait for refresh when indexing data.
-    // Normally this isn't a good idea, but is ok for this example.
-    let index_params = RequestParams::default()
-        .url_param("refresh", true);
-
-    let doc = MyType {
-        id: 1,
-        title: String::from("A title"),
-        timestamp: Date::now()
-    };
-
-    // Create the index if it doesn't already exist
-    match client.elastic_req(&params, index_exists()).unwrap().status() {
-        &StatusCode::NotFound => {
-            client.elastic_req(&params, put_index()).unwrap();
-        },
-        _ => ()
-    }
-
-    // Update the document mapping and index our document
-    client.elastic_req(&params, map_doc(&doc)).unwrap();
-    client.elastic_req(&index_params, put_doc(&doc)).unwrap();
-
-    // Search for documents in the index
-    let res: serde_json::Value = client
-        .elastic_req(&params, search()).unwrap()
-        .json().unwrap();
-
-    println!("{:?}", res);
+fn search_docs(client: &Client, params: &RequestParams) -> serde_json::Value {
+    client.request(&params, search()).and_then(|res| res.json()).unwrap()
 }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,0 +1,100 @@
+use serde::Deserialize;
+use reqwest::{self, Client as HttpClient};
+use elastic_reqwest::ElasticClient;
+use super::errors::*;
+
+pub use reqwest::StatusCode;
+pub use elastic_reqwest::RequestParams;
+
+/// Request types the Elasticsearch REST API.
+pub use elastic_requests::*;
+
+/// Response types for the Elasticsearch REST API.
+pub use elastic_responses::*;
+
+/// A HTTP client for the Elasticsearch REST API.
+pub struct Client {
+    http: HttpClient,
+    params: RequestParams,
+}
+
+/// A builder for a request.
+pub struct RequestBuilder<'a, I> {
+    client: &'a Client,
+    params: Option<RequestParams>,
+    req: I,
+}
+
+impl<'a, I> RequestBuilder<'a, I> {
+    /// Manually construct a `RequestBuilder`.
+    /// 
+    /// If the `params` are `None`, then the `RequestParams` from the
+    /// `client` are used.
+    pub fn new(client: &'a Client, params: Option<RequestParams>, req: I) -> Self {
+        RequestBuilder {
+            client: client,
+            params: params,
+            req: req
+        }
+    }
+}
+
+impl<'a, I> RequestBuilder<'a, I>
+    where I: Into<HttpRequest<'static>>
+{
+    /// Override the parameters for this request.
+    /// 
+    /// This method will clone the `RequestParams` on the `Client`.
+    pub fn params<F>(mut self, builder: F) -> Self 
+        where F: Fn(RequestParams) -> RequestParams
+    {
+        self.params = Some(builder(self.client.params.clone()));
+
+        self
+    }
+
+    /// Send this request and return the response.
+    pub fn send(self) -> Result<HttpResponse> {
+        let params = self.params.as_ref().unwrap_or(&self.client.params);
+
+        let res = self.client.http.elastic_req(params, self.req)?;
+
+        Ok(HttpResponse(res))
+    }
+}
+
+impl Client {
+    /// Create a new client for the given parameters.
+    pub fn new(params: RequestParams) -> Result<Self> {
+        let client = HttpClient::new()?;
+
+        Ok(Client {
+            http: client,
+            params: params,
+        })
+    }
+
+    /// Create a `RequestBuilder` that can be configured before sending.
+    pub fn request<'a, I>(&'a self, req: I) -> RequestBuilder<'a, I>
+        where I: Into<HttpRequest<'static>>
+    {
+        RequestBuilder::new(&self, None, req)
+    }
+}
+
+/// A raw HTTP response.
+pub struct HttpResponse(reqwest::Response);
+
+impl HttpResponse {
+    /// Get the `reqwest` response.
+    pub fn raw(self) -> reqwest::Response {
+        self.0
+    }
+
+    /// Get the response body as JSON.
+    pub fn json<T>(mut self) -> Result<T>
+        where T: Deserialize
+    {
+        self.0.json().map_err(|e| e.into())
+    }
+}

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -28,8 +28,8 @@ pub struct RequestBuilder<'a, I> {
 impl<'a, I> RequestBuilder<'a, I> {
     /// Manually construct a `RequestBuilder`.
     /// 
-    /// If the `params` are `None`, then the `RequestParams` from the
-    /// `client` are used.
+    /// If the `RequestParams` are `None`, then the parameters from the
+    /// `Client` are used.
     pub fn new(client: &'a Client, params: Option<RequestParams>, req: I) -> Self {
         RequestBuilder {
             client: client,
@@ -44,7 +44,8 @@ impl<'a, I> RequestBuilder<'a, I>
 {
     /// Override the parameters for this request.
     /// 
-    /// This method will clone the `RequestParams` on the `Client`.
+    /// This method will clone the `RequestParams` on the `Client` and pass
+    /// them to the closure.
     pub fn params<F>(mut self, builder: F) -> Self 
         where F: Fn(RequestParams) -> RequestParams
     {
@@ -65,6 +66,10 @@ impl<'a, I> RequestBuilder<'a, I>
 
 impl Client {
     /// Create a new client for the given parameters.
+    /// 
+    /// The parameters given here are used as the defaults for any
+    /// request made by this client, but can be overriden on a
+    /// per-request basis.
     pub fn new(params: RequestParams) -> Result<Self> {
         let client = HttpClient::new()?;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,0 +1,73 @@
+use serde::Serialize;
+use serde_json;
+use super::client::{Index, Id, Body, IndexRequest, IndicesPutMappingRequest};
+use super::types::prelude::*;
+
+use super::errors::*;
+
+/// A trait for converting a document into a request.
+pub trait TryForDoc<T, M>: Sized {
+    fn try_for_doc(doc: T) -> Result<Self>;
+}
+
+/// A trait for converting a document mapping into a request.
+pub trait TryForMapping<M> 
+    where Self: Sized
+{
+    fn try_for_mapping(mapping: M) -> Result<Self>;
+}
+
+impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndexRequest<'a>
+    where T: DocumentType<M>,
+          M: DocumentMapping
+{
+    fn try_for_doc((index, doc): (Index<'a>, &'b T)) -> Result<Self> {
+        let ty = T::name();
+
+        let doc = serde_json::to_string(&doc)?;
+
+        Ok(Self::for_index_ty(index, ty, doc))
+    }
+}
+
+impl<'a, 'b, T, M> TryForDoc<(Index<'a>, Id<'a>, &'b T), M> for IndexRequest<'a>
+    where T: DocumentType<M>,
+          M: DocumentMapping
+{
+    fn try_for_doc((index, id, doc): (Index<'a>, Id<'a>, &'b T)) -> Result<Self> {
+        let ty = T::name();
+
+        let doc = serde_json::to_string(&doc)?;
+
+        Ok(Self::for_index_ty_id(index, ty, id, doc))
+    }
+}
+
+impl<'a, 'b, T> TryForDoc<&'b T, ()> for Body<'a>
+    where T: Serialize
+{
+    fn try_for_doc(doc: &T) -> Result<Self> {
+        let doc = serde_json::to_string(&doc)?;
+
+        Ok(Self::from(doc))
+    }
+}
+
+impl<'a, M> TryForMapping<(Index<'a>, M)> for IndicesPutMappingRequest<'a>
+    where M: DocumentMapping
+{
+    fn try_for_mapping((index, mapping): (Index<'a>, M)) -> Result<Self> {
+        let mapping = serde_json::to_string(&Document::from(mapping))?;
+
+        Ok(Self::for_index_ty(index, M::name(), mapping))
+    }
+}
+
+impl <'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndicesPutMappingRequest<'a>
+    where T: DocumentType<M>,
+          M: DocumentMapping
+{
+    fn try_for_doc((index, _): (Index<'a>, &'b T)) -> Result<Self> {
+        Self::try_for_mapping((index, T::mapping()))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod errors;
 pub mod client {
     //! HTTP client, requests and responses.
     //!
-    //! This module contains the core `ElasticClient` trait, as well
+    //! This module contains the HTTP client, as well
     //! as request and response types.
 
     pub use super::http_client::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@ pub mod client {
     //! This module contains the core `ElasticClient` trait, as well
     //! as request and response types.
 
-    pub use reqwest::{Client, Response as HttpResponse, StatusCode};
+    pub use reqwest::{StatusCode};
 
     /// A client wrapper over [`reqwest`](https://github.com/seanmonstar/reqwest).
-    pub use elastic_reqwest::*;
+    pub use elastic_reqwest::{RequestParams};
 
     /// Request types the Elasticsearch REST API.
     pub use elastic_requests::*;
@@ -32,11 +32,43 @@ pub mod client {
     /// Response types for the Elasticsearch REST API.
     pub use elastic_responses::*;
 
-    use serde::Serialize;
+    use serde::{Serialize, Deserialize};
     use serde_json;
 
     use super::errors::*;
+    use reqwest::{self, Client as HttpClient};
+    use elastic_reqwest::ElasticClient;
     use super::types::prelude::{FieldType, Document, DocumentType, DocumentMapping};
+
+    pub struct Client(HttpClient);
+    pub struct HttpResponse(reqwest::Response);
+
+    impl Client {
+        pub fn new() -> Result<Self> {
+            let client = HttpClient::new()?;
+            Ok(Client(client))
+        }
+
+        pub fn request<I>(&self, params: &RequestParams, req: I) -> Result<HttpResponse>
+            where I: Into<HttpRequest<'static>>
+        {
+            let res = self.0.elastic_req(params, req)?;
+
+            Ok(HttpResponse(res))
+        }
+    }
+
+    impl HttpResponse {
+        pub fn raw(self) -> reqwest::Response {
+            self.0
+        }
+
+        pub fn json<T>(mut self) -> Result<T>
+            where T: Deserialize
+        {
+            self.0.json().map_err(|e| e.into())
+        }
+    }
 
     /// A trait for converting a document into a request.
     pub trait TryForDoc<T, M>: Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ extern crate elastic_requests;
 extern crate elastic_types;
 extern crate elastic_responses;
 
+mod http_client;
+mod impls;
+
 pub mod errors;
 
 pub mod client {
@@ -21,121 +24,8 @@ pub mod client {
     //! This module contains the core `ElasticClient` trait, as well
     //! as request and response types.
 
-    pub use reqwest::{StatusCode};
-
-    /// A client wrapper over [`reqwest`](https://github.com/seanmonstar/reqwest).
-    pub use elastic_reqwest::{RequestParams};
-
-    /// Request types the Elasticsearch REST API.
-    pub use elastic_requests::*;
-
-    /// Response types for the Elasticsearch REST API.
-    pub use elastic_responses::*;
-
-    use serde::{Serialize, Deserialize};
-    use serde_json;
-
-    use super::errors::*;
-    use reqwest::{self, Client as HttpClient};
-    use elastic_reqwest::ElasticClient;
-    use super::types::prelude::{FieldType, Document, DocumentType, DocumentMapping};
-
-    pub struct Client(HttpClient);
-    pub struct HttpResponse(reqwest::Response);
-
-    impl Client {
-        pub fn new() -> Result<Self> {
-            let client = HttpClient::new()?;
-            Ok(Client(client))
-        }
-
-        pub fn request<I>(&self, params: &RequestParams, req: I) -> Result<HttpResponse>
-            where I: Into<HttpRequest<'static>>
-        {
-            let res = self.0.elastic_req(params, req)?;
-
-            Ok(HttpResponse(res))
-        }
-    }
-
-    impl HttpResponse {
-        pub fn raw(self) -> reqwest::Response {
-            self.0
-        }
-
-        pub fn json<T>(mut self) -> Result<T>
-            where T: Deserialize
-        {
-            self.0.json().map_err(|e| e.into())
-        }
-    }
-
-    /// A trait for converting a document into a request.
-    pub trait TryForDoc<T, M>: Sized {
-        fn try_for_doc(doc: T) -> Result<Self>;
-    }
-
-    /// A trait for converting a document mapping into a request.
-    pub trait TryForMapping<M> 
-        where Self: Sized
-    {
-        fn try_for_mapping(mapping: M) -> Result<Self>;
-    }
-
-    impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndexRequest<'a>
-        where T: DocumentType<M>,
-              M: DocumentMapping
-    {
-        fn try_for_doc((index, doc): (Index<'a>, &'b T)) -> Result<Self> {
-            let ty = T::name();
-
-            let doc = serde_json::to_string(&doc)?;
-
-            Ok(Self::for_index_ty(index, ty, doc))
-        }
-    }
-
-    impl<'a, 'b, T, M> TryForDoc<(Index<'a>, Id<'a>, &'b T), M> for IndexRequest<'a>
-        where T: DocumentType<M>,
-              M: DocumentMapping
-    {
-        fn try_for_doc((index, id, doc): (Index<'a>, Id<'a>, &'b T)) -> Result<Self> {
-            let ty = T::name();
-
-            let doc = serde_json::to_string(&doc)?;
-
-            Ok(Self::for_index_ty_id(index, ty, id, doc))
-        }
-    }
-
-    impl<'a, 'b, T> TryForDoc<&'b T, ()> for Body<'a>
-        where T: Serialize
-    {
-        fn try_for_doc(doc: &T) -> Result<Self> {
-            let doc = serde_json::to_string(&doc)?;
-
-            Ok(Self::from(doc))
-        }
-    }
-
-    impl<'a, M> TryForMapping<(Index<'a>, M)> for IndicesPutMappingRequest<'a>
-        where M: DocumentMapping
-    {
-        fn try_for_mapping((index, mapping): (Index<'a>, M)) -> Result<Self> {
-            let mapping = serde_json::to_string(&Document::from(mapping))?;
-
-            Ok(Self::for_index_ty(index, M::name(), mapping))
-        }
-    }
-
-    impl <'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndicesPutMappingRequest<'a>
-        where T: DocumentType<M>,
-              M: DocumentMapping
-    {
-        fn try_for_doc((index, _): (Index<'a>, &'b T)) -> Result<Self> {
-            Self::try_for_mapping((index, T::mapping()))
-        }
-    }
+    pub use super::http_client::*;
+    pub use super::impls::*;
 }
 
 pub mod types {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -5,7 +5,7 @@ extern crate serde_derive;
 extern crate serde;
 extern crate elastic;
 
-use elastic::client::{self, TryForDoc};
+use elastic::prelude::*;
 
 #[derive(Serialize, ElasticType)]
 struct MyType {
@@ -20,9 +20,59 @@ fn index_request_from_doc() {
         title: "A title"
     };
 
-    let index = client::Index::from("test_index");
+    let index = Index::from("test_index");
 
-    let req = client::IndexRequest::try_for_doc((index, &doc));
+    let req = IndexRequest::try_for_doc((index, &doc));
 
     assert!(req.is_ok());
+}
+
+#[test]
+fn index_request_from_doc_with_id() {
+    let doc = MyType {
+        id: 1,
+        title: "A title"
+    };
+
+    let index = Index::from("test_index");
+    let id = Id::from(doc.id.to_string());
+
+    let req = IndexRequest::try_for_doc((index, id, &doc));
+
+    assert!(req.is_ok());
+}
+
+#[test]
+fn mapping_request_from_doc() {
+	let doc = MyType {
+		id: 1,
+		title: "A title"
+	};
+
+	let index = Index::from("test_index");
+
+	let req = IndicesPutMappingRequest::try_for_doc((index, &doc));
+
+	assert!(req.is_ok());
+}
+
+#[test]
+fn mapping_request_from_mapping() {
+	let index = Index::from("test_index");
+
+	let req = IndicesPutMappingRequest::try_for_mapping((index, MyType::mapping()));
+
+	assert!(req.is_ok());
+}
+
+#[test]
+fn body_from_doc() {
+	let doc = MyType {
+		id: 1,
+		title: "A title"
+	};
+
+	let body = Body::try_for_doc(&doc);
+
+	assert!(body.is_ok());
 }


### PR DESCRIPTION
This PR stops re-exporting bits of `elastic_reqwest` and wraps them up in a common `Client` API. The samples have been updated appropriately.

Once this is sorted the current API surface should be cleaned up with some proper tests and refactored into separate modules for better maintainability.