### PR TITLE
[WIP] Documentation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -80,6 +80,7 @@ pub use elastic_reqwest::RequestParams;
 /// A HTTP client for the Elasticsearch REST API.
 /// 
 /// The `Client` is a structure that lets you create and send `RequestBuilder`s.
+/// It's mostly a thin wrapper over a `reqwest::Client`.
 pub struct Client {
     http: HttpClient,
     params: RequestParams,
@@ -91,6 +92,26 @@ impl Client {
     /// The parameters given here are used as the defaults for any
     /// request made by this client, but can be overriden on a
     /// per-request basis.
+    /// This method can return a `HttpError` if the underlying `reqwest::Client`
+    /// fails to create.
+    /// 
+    /// # Examples
+    /// 
+    /// Create a `Client` with default parameters:
+    /// 
+    /// ```
+    /// # use elastic::prelude::*;
+    /// let client = Client::new(RequestParams::default()).unwrap();
+    /// ```
+    /// 
+    /// Create a `Client` for a specific node:
+    /// 
+    /// ```
+    /// # use elastic::prelude::*;
+    /// let client = Client::new(RequestParams::new("http://eshost:9200")).unwrap();
+    /// ```
+    /// 
+    /// See [`RequestParams`](struct.RequestParams.html) for more configuration options.
     pub fn new(params: RequestParams) -> Result<Self> {
         let client = HttpClient::new()?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,19 +12,19 @@
 //! 
 //! The basic flow from request to response is:
 //! 
-//! **1)** Turn a concrete [request type](requests/endpoints/index.html) into a [`RequestBuilder`]():
+//! **1)** Turn a concrete [request type](requests/endpoints/index.html) into a [`RequestBuilder`](struct.RequestBuilder.html):
 //! 
 //! ```text
 //! [RequestType] ----------------> [Client.request()] -> [RequestBuilder]
 //! ```
 //! 
-//! **2)** Send the [`RequestBuilder`]() and get a [`ResponseBuilder`]():
+//! **2)** Send the [`RequestBuilder`](struct.RequestBuilder.html) and get a [`ResponseBuilder`](struct.ResponseBuilder.html):
 //! 
 //! ```text
 //! [RequestBuilder.send()] ------> [ResponseBuilder] 
 //! ```
 //! 
-//! **3)** Parse the [`ResponseBuilder`]() to a [response type](responses/parse/trait.FromResponse.html#Implementors):
+//! **3)** Parse the [`ResponseBuilder`](struct.ResponseBuilder.html) to a [response type](responses/parse/trait.FromResponse.html#Implementors):
 //! 
 //! ```text
 //! [ResponseBuilder.response()] -> [ResponseType]
@@ -122,6 +122,27 @@ impl Client {
     }
 
     /// Create a `RequestBuilder` that can be configured before sending.
+    /// 
+    /// The `request` method accepts any type that can be converted into
+    /// a [`HttpRequest<'static>`](requests/struct.HttpRequest.html), 
+    /// which includes the endpoint types in the [`requests`](requests/endpoints/index.html) module.
+    ///
+    /// # Examples
+    /// 
+    /// Turn a concrete request into a `RequestBuilder`:
+    /// 
+    /// ```
+    /// # use elastic::prelude::*;
+    /// # let client = Client::new(RequestParams::default()).unwrap();
+    /// // `PingRequest` implements `Into<HttpRequest>`
+    /// let req = PingRequest::new();
+    /// 
+    /// // Turn the `PingRequest` into a `RequestBuilder`
+    /// let builder = client.request(req);
+    /// 
+    /// // Send the `RequestBuilder`
+    /// let res = builder.send().unwrap();
+    /// ```
     pub fn request<'a, I>(&'a self, req: I) -> RequestBuilder<'a, I>
         where I: Into<HttpRequest<'static>>
     {
@@ -248,6 +269,8 @@ pub mod responses {
     pub use elastic_responses::{HttpResponse, AggregationIterator, Aggregations, Hit, Hits, Shards};
 
     pub mod parse {
+        //! Utility types for response parsing.
+
         pub use elastic_responses::FromResponse;
         pub use elastic_responses::parse::{MaybeOkResponse, MaybeBufferedResponse,
                                            UnbufferedResponse, BufferedResponse};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,50 @@
 //! Client-side error types.
+//! 
+//! The main `Error` type combines the various kinds of errors
+//! that can occur when interacting with Elasticsearch.
+//! These include:
+//! 
+//! - `Api`: an error directly from an Elasticsearch exception,
+//! like `index_not_found`.
+//! This is the probably the variant you'll be interested in handling.
+//! - `Json`: a general error serialising or deserialising json.
+//! - `Http`: a general error in the http transport.
+//! 
+//! # Examples
+//! 
+//! Any method defined in `elastic` that could fail will return a
+//! `Result<T, Error>` that can be matched on.
+//! The below example sends a request and then checks the response
+//! for an `ErrorKind::Api`:
+//! 
+//! ```no_run
+//! # use elastic::prelude::*;
+//! # use elastic::error::*;
+//! # let client = Client::new(RequestParams::default()).unwrap();
+//! # let req = PingRequest::new();
+//! // Send a request.
+//! // This will return a Result<ResponseBuilder, Error>
+//! let res = client.request(req)
+//!                 .send();
+//! 
+//! match res {
+//!     Ok(response) => {
+//!         // do something with the response
+//!     },
+//!     Err(e) => {
+//!         match *e.kind() {
+//!             ErrorKind::Api(ref e) => {
+//!                 // handle a REST API error
+//!             },
+//!             ref e => {
+//!                 // handle a HTTP or JSON error
+//!             }
+//!         }
+//!     }
+//! }
+//! ```
+
+#![allow(missing_docs)]
 
 pub use serde_json::Error as JsonError;
 pub use reqwest::Error as HttpError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//! Client-side error types.
+
 pub use serde_json::Error as JsonError;
 pub use reqwest::Error as HttpError;
 pub use elastic_responses::error::{ApiError, ResponseError};

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -13,13 +13,15 @@ use super::types::prelude::*;
 
 use super::error::*;
 
-/// A trait for converting a document into a request.
+/// A trait for converting a [document](../../types/document/index.html)
+/// into a [request](endpoints/index.html).
 pub trait TryForDoc<T, M>: Sized {
     /// Try convert a document into a request type.
     fn try_for_doc(doc: T) -> Result<Self>;
 }
 
-/// A trait for converting a document mapping into a request.
+/// A trait for converting a [document mapping](../../types/document/trait.DocumentMapping.html) 
+/// mapping into a [request](endpoints/index.html).
 pub trait TryForMapping<M>
     where Self: Sized
 {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,3 +1,11 @@
+//! Glue traits for documents and requests.
+//! 
+//! The `TryForDoc` and `TryForMapping` traits are functionally equivalent
+//! but are used to support different conversions.
+//! They are implemented for tuples of a document and additional parameters,
+//! this may be different in a future where indices only support a single
+//! document type.
+
 use serde::Serialize;
 use serde_json;
 use super::client::requests::{Index, Id, Body, IndexRequest, IndicesPutMappingRequest};
@@ -7,6 +15,7 @@ use super::error::*;
 
 /// A trait for converting a document into a request.
 pub trait TryForDoc<T, M>: Sized {
+    /// Try convert a document into a request type.
     fn try_for_doc(doc: T) -> Result<Self>;
 }
 
@@ -14,6 +23,7 @@ pub trait TryForDoc<T, M>: Sized {
 pub trait TryForMapping<M>
     where Self: Sized
 {
+    /// Try convert a document mapping into a request.
     fn try_for_mapping(mapping: M) -> Result<Self>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Elasticsearch API Client
 //!
-//! An efficient native client for the Elasticsearch REST API.
+//! A modular and efficient native client for the Elasticsearch REST API.
 //!
 //! # Supported Versions
 //!
@@ -8,15 +8,12 @@
 //!  --------------- | -------------
 //!  `0.x`           | `5.x`
 //!
-//! This crate is mostly a meta-package composed of a number of smaller pieces including:
-//!
-//! - `elastic_reqwest` HTTP transport
-//! - `elastic_requests` API request builders
-//! - `elastic_responses` API response parser
-//! - `elastic_types` tools for document and mapping APIs
-//!
-//! This crate glues these libraries together with some simple assumptions
-//! about how they're going to be used.
+//! The client provides a flexible API with a default happy-path so you can customise the
+//! way you use it.
+//! It depends heavily on the following crates:
+//! 
+//! - [`reqwest`/`hyper`]() as the default HTTP layer
+//! - [`serde`/`serde_json`]() for serialisation.
 //!
 //! # Usage
 //!
@@ -34,6 +31,7 @@
 //! elastic_types_derive = { version = "*", features = ["elastic"] }
 //! json_str = "*"
 //! serde = "*"
+//! serde_json = "*"
 //! serde_derive = "*"
 //! ```
 //!
@@ -44,6 +42,7 @@
 //!
 //! // Optional
 //! extern crate serde;
+//! extern crate sede_json;
 //! #[macro_use]
 //! extern crate serde_derive;
 //! #[macro_use]
@@ -56,6 +55,10 @@
 //! # Examples
 //!
 //! ## Making requests
+//! 
+//! Each endpoint in the Elasticsearch REST API is provided as a strongly-typed
+//! structure.
+//! Use a `Client` instance to send one of these requests and read the response:
 //!
 //! ```no_run
 //! use elastic::prelude::*;
@@ -66,9 +69,8 @@
 //! let response = client.request(req).send().unwrap();
 //! ```
 //!
-//! ## Configuring requests
-//!
-//! Create a set of request parameters that are passed to each request:
+//! The `Client` will use a default set of request parameters that are passed to each request.
+//! Properties like the host and query parameters can be configured:
 //!
 //! ```no_run
 //! # use elastic::prelude::*;
@@ -78,7 +80,7 @@
 //! let client = Client::new(params).unwrap();
 //! ```
 //!
-//! Requests can override parameter values:
+//! Individual requests can override these parameter values:
 //!
 //! ```no_run
 //! # use elastic::prelude::*;
@@ -90,9 +92,65 @@
 //!     .send()
 //!     .unwrap();
 //! ```
+//! 
+//! For more details, see the [`client`](client/index.html) and [`requests`](client/requests/index.html) modules.
+//! 
+//! ## Getting Responses
+//!
+//! Call `response` on a sent request to get a `SearchResponse` or `GetResponse`:
+//!
+//! ```no_run
+//! # extern crate serde;
+//! # #[macro_use]
+//! # extern crate serde_derive;
+//! # #[macro_use]
+//! # extern crate elastic_types_derive;
+//! # extern crate elastic;
+//! # use elastic::prelude::*;
+//! # fn main() {
+//! # #[derive(Serialize, Deserialize, ElasticType)]
+//! # struct MyType {
+//! #     pub id: i32,
+//! #     pub title: String,
+//! #     pub timestamp: Date<DefaultDateFormat>
+//! # }
+//! # let params = RequestParams::new("http://es_host:9200");
+//! # let client = Client::new(params).unwrap();
+//! # let req = PingRequest::new();
+//! let response = client.request(req)
+//!     .send()
+//!     .and_then(|res| res.response::<SearchResponse<MyType>>());
+//! # }
+//! ```
+//!
+//! Call `raw` on a sent request to get a raw `HttpResponse`:
+//!
+//! ```no_run
+//! # extern crate serde;
+//! # #[macro_use]
+//! # extern crate serde_derive;
+//! # #[macro_use]
+//! # extern crate elastic_types_derive;
+//! # extern crate elastic;
+//! # use elastic::prelude::*;
+//! # fn main() {
+//! # let params = RequestParams::new("http://es_host:9200");
+//! # let client = Client::new(params).unwrap();
+//! # let req = PingRequest::new();
+//! let response = client.request(req)
+//!     .send()
+//!     .map(|res| res.raw());
+//! # }
+//! ```
+//!
+//! The `HttpResponse` implements `Read` so you can buffer out the raw
+//! response data.
+//! 
+//! For more details see the [`responses`](client/responses/index.html) module.
 //!
 //! ## Defining document types
 //!
+//! The Mapping API is provided as a custom derive plugin and Rust traits.
 //! Derive `Serialize`, `Deserialize` and `ElasticType` on your document types:
 //!
 //! ```no_run
@@ -166,60 +224,23 @@
 //! let req = IndicesPutMappingRequest::try_for_mapping((index, mapping)).unwrap();
 //! # }
 //! ```
+//!
+//! For more details on document types, see the [`types`](types) module.
 //! 
-//! For more details on document types, see 
-//! [`elastic_types`](https://docs.rs/elastic_types/*/elastic_types/#map-your-types).
+//! # Crate design
 //! 
-//! ## Getting Responses
-//! 
-//! Call `response` on a sent request to get a `SearchResponse` or `GetResponse`:
-//! 
-//! ```no_run
-//! # extern crate serde;
-//! # #[macro_use]
-//! # extern crate serde_derive;
-//! # #[macro_use]
-//! # extern crate elastic_types_derive;
-//! # extern crate elastic;
-//! # use elastic::prelude::*;
-//! # fn main() {
-//! # #[derive(Serialize, Deserialize, ElasticType)]
-//! # struct MyType {
-//! #     pub id: i32,
-//! #     pub title: String,
-//! #     pub timestamp: Date<DefaultDateFormat>
-//! # }
-//! # let params = RequestParams::new("http://es_host:9200");
-//! # let client = Client::new(params).unwrap();
-//! # let req = PingRequest::new();
-//! let response = client.request(req)
-//!     .send()
-//!     .and_then(|res| res.response::<SearchResponse<MyType>>());
-//! # }
-//! ```
-//! 
-//! Call `raw` on a sent request to get a raw `reqwest::Response`:
-//! 
-//! ```no_run
-//! # extern crate serde;
-//! # #[macro_use]
-//! # extern crate serde_derive;
-//! # #[macro_use]
-//! # extern crate elastic_types_derive;
-//! # extern crate elastic;
-//! # use elastic::prelude::*;
-//! # fn main() {
-//! # let params = RequestParams::new("http://es_host:9200");
-//! # let client = Client::new(params).unwrap();
-//! # let req = PingRequest::new();
-//! let response = client.request(req)
-//!     .send()
-//!     .map(|res| res.raw());
-//! # }
-//! ```
-//! 
-//! You should avoid depending on `raw` too much, because it's
-//! a leaky abstraction that may be removed in the future.
+//! This crate is mostly a meta-package composed of a number of smaller pieces including:
+//!
+//! - `elastic_reqwest` HTTP transport
+//! - `elastic_requests` API request builders
+//! - `elastic_responses` API response parser
+//! - `elastic_types` tools for document and mapping APIs
+//!
+//! This crate glues these libraries together with some simple assumptions
+//! about how they're going to be used.
+
+#![deny(warnings)]
+#![deny(missing_docs)]
 
 #[macro_use]
 extern crate error_chain;
@@ -233,30 +254,204 @@ extern crate elastic_responses;
 
 mod impls;
 
-/// Client-side error types.
 pub mod error;
 
-/// HTTP headers and status codes.
 pub mod http {
+    //! HTTP headers and status codes.
+
     pub use reqwest::header;
 }
 
-/// HTTP client, requests and responses.
-///
-/// This module contains the HTTP client, as well
-/// as request and response types.
 pub mod client;
 
-/// Indexable documents and type mapping.
-///
-/// This module contains tools for defining Elasticsearch-compatible
-/// document types.
 pub mod types {
+    //! Indexable documents and type mapping.
+    //!
+    //! This module contains tools for defining Elasticsearch-compatible
+    //! document types.
+    //! Document mapping is defined using Rust traits, which are added to fields
+    //! as generic parameters.
+    //! This has the following benefits:
+    //!
+    //! - Your `struct` is the one source of truth for serialisation and mapping.
+    //! There's no extra mapping function to maintain.
+    //! - Mapping is immutable and zero-cost. You don't pay anything at runtime
+    //! for having mapping metadata available.
+    //! 
+    //! # Document and data types
+    //!
+    //! Types in Elasticsearch are a combination of _source_ and _mapping_.
+    //! The source is the data (like `42` or `"my string"`) and the mapping is metadata about how to
+    //! interpret and use the data (like the format of a date string).
+    //!
+    //! The approach `elastic` takes to types is to bundle the mapping up as a _Zero Sized Type_,
+    //! which is then bound to a field type as a generic parameter. For example:
+    //!
+    //! ```ignore
+    //! some_field: Boolean<MyMapping>
+    //! ```
+    //!
+    //! The source type is `boolean` and the mapping is `MyMapping`.
+    //! 
+    //! Most datatypes also implement a default mapping for a common Rust type if you don't
+    //! need to customise how a field is mapped:
+    //! 
+    //! ```ignore
+    //! some_field: bool
+    //! ```
+    //! 
+    //! See the table below for a complete list of supported datatypes and their default
+    //! implementations.
+    //!
+    //! All Elasticsearch types implement the base `FieldType<M: FieldMapping<F>, F>` trait
+    //! where `M` is the mapping and `F` is a type-specific format.
+    //!
+    //! ## Supported datatypes
+    //! 
+    //! The following table illustrates the types provided by `elastic`:
+    //!
+    //!  Elasticsearch Type  | Rust Type (Default Mapping) | Crate     | Rust Type (Custom Mapping)                                                       | Format Type
+    //!  ------------------- | --------------------------- | --------- | -------------------------------------------------------------------------------- | -----------------
+    //!  `object`            | -                           | -         | type implementing [`DocumentType<M>`](document/index.html)                       | -
+    //!  `integer`           | `i32`                       | `std`     | [`Integer<M>`](number/index.html)                                                | -
+    //!  `long`              | `i64`                       | `std`     | [`Long<M>`](number/index.html)                                                   | -
+    //!  `short`             | `i16`                       | `std`     | [`Short<M>`](number/index.html)                                                  | -
+    //!  `byte`              | `i8`                        | `std`     | [`Byte<M>`](number/index.html)                                                   | -
+    //!  `float`             | `f32`                       | `std`     | [`Float<M>`](number/index.html)                                                  | -
+    //!  `double`            | `f64`                       | `std`     | [`Double<M>`](number/index.html)                                                 | -
+    //!  `keyword`           | -                           | -         | [`Keyword<M>`](string/index.html)                                                | -
+    //!  `text`              | `String`                    | `std`     | [`Text<M>`](string/index.html)                                                   | -
+    //!  `boolean`           | `bool`                      | `std`     | [`Boolean<M>`](boolean/index.html)                                               | -
+    //!  `ip`                | `Ipv4Addr`                  | `std`     | [`Ip<M>`](ip/index.html)                                                         | -
+    //!  `date`              | `DateTime<UTC>`             | `chrono`  | [`Date<F, M>`](date/index.html)                                                  | `DateFormat`
+    //!  `geo_point`         | `Point`                     | `geo`     | [`GeoPoint<F, M>`](geo/point/index.html)                                         | `GeoPointFormat`
+    //!  `geo_shape`         | -                           | `geojson` | [`GeoShape<M>`](geo/shape/index.html)                                            | -
+    //!
+    //! ## Mapping
+    //!
+    //! Having the mapping available at compile-time captures the fact that a mapping is static and tied
+    //! to the data type.
+    //!
+    //! Where there's a `std` type that's equivalent to an Elasticsearch type (like `i32` for `integer`),
+    //! a default mapping is implemented for that type.
+    //! That means you can use primitives in your structs and have them mapped to the correct type in Elasticsearch.
+    //! If you want to provide your own mapping for a `std` type, there's also a struct provided by `elastic_types`
+    //! that wraps the `std` type but also takes an explicit mapping (like `Integer` which implements `Deref<Target = i32>`).
+    //!
+    //! Where there isn't a `std` type available (like `date`), an external crate is used and an implementation of
+    //! that type is provided (like `Date`, which implements `Deref<Target = chrono::DateTime<UTC>>`).
+    //!
+    //! ## Formats
+    //!
+    //! For some types (like `Date`), it's helpful to have an extra generic parameter that describes the
+    //! way the data can be interpreted. For most types the format isn't exposed, because there aren't any alternative formats available.
+    //! This is a particularly helpful feature for serialisation.
+    //!
+    //! # Examples
+    //!
+    //! ## Derive document mapping
+    //!
+    //! Document types must derive `serde`'s [serialisation traits]().
+    //! Use simple generic types to annotate your Rust structures with Elasticsearch
+    //! document field mappings:
+    //!
+    //! ```
+    //! #[derive(Serialize, Deserialize, ElasticType)]
+    //! struct MyType {
+    //!     // Mapped as an `integer` field
+    //!     id: i32,
+    //!     // Mapped as a `text` field with a `keyword` subfield
+    //!     title: String,
+    //!     // Mapped as a `date` with an `epoch_millis` format
+    //!     timestamp: Date<EpochMillis>
+    //! }
+    //! ```
+    //!
+    //! You can use the `Document` type wrapper to serialise the mapping for your
+    //! document types:
+    //!
+    //! ```
+    //! let doc = Document::from(MyType::mapping());
+    //!
+    //! let mapping = serde_json::to_string(&doc).unwrap();
+    //! ```
+    //!
+    //! This will produce the following JSON:
+    //!
+    //! ```
+    //! # let expected = json_str!(
+    //! {
+    //!     "properties": {
+    //!         "id": {
+    //!             "type": "integer"
+    //!         },
+    //!         "title": {
+    //!             "type": "text",
+    //!             "fields": {
+    //!                 "keyword": {
+    //!                     "type": "keyword",
+    //!                     "ignore_above": 256
+    //!                 }
+    //!             }
+    //!         },
+    //!         "timestamp": {
+    //!             "type": "date",
+    //!             "format": "epoch_millis"
+    //!         }
+    //!     }
+    //! }
+    //! # );
+    //! ```
+    //! 
+    //! See the table above for a list of all supported datatypes and how to work
+    //! with them.
+    //!
+    //! ## Define custom field data types
+    //!
+    //! Use traits to define your own field types and have them mapped as one of the
+    //! core datatypes:
+    //!
+    //! ```
+    //! # #[derive(Default, Serialize, Deserialize)]
+    //! enum MyEnum {
+    //!     OptionA,
+    //!     OptionB,
+    //!     OptionC
+    //! }
+    //!
+    //! // Map `MyEnum` as a `keyword` in Elasticsearch, but treat it as an enum in Rust
+    //! impl FieldType<DefaultKeywordMapping, KeywordFormat> for MyEnum {}
+    //! ```
+    //! 
+    //! You can then use `MyEnum` on any document type:
+    //! 
+    //! ```
+    //! #[derive(Serialize, Deserialize, ElasticType)]
+    //! struct MyType {
+    //!     value: MyEnum
+    //! }
+    //! ```
+    //! 
+    //! Serialising `MyType`s mapping will produce the following json:
+    //! 
+    //! ```
+    //! # let expected = json_str!(
+    //! {
+    //!     "properties": {
+    //!         "value": {
+    //!             "type": "keyword"
+    //!         }
+    //!     }
+    //! }
+    //! # );
+    //! ```
+
     pub use elastic_types::{document, field, boolean, date, geo, ip, number, string, prelude};
 }
 
-/// A glob import for convenience.
 pub mod prelude {
+    //! A glob import for convenience.
+
     pub use super::client::{Client, RequestParams, RequestBuilder, ResponseBuilder};
     pub use super::client::requests::*;
     pub use super::client::responses::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //! way you use it.
 //! It depends heavily on the following crates:
 //! 
-//! - [`reqwest`/`hyper`]() as the default HTTP layer
-//! - [`serde`/`serde_json`]() for serialisation.
+//! - [`reqwest`/`hyper`](https://github.com/seanmonstar/reqwest) as the default HTTP layer
+//! - [`serde`/`serde_json`](https://serde.rs/) for serialisation.
 //!
 //! # Usage
 //!
@@ -63,9 +63,13 @@
 //! ```no_run
 //! use elastic::prelude::*;
 //!
+//! // Create a client with default params (host: 'http://localhost:9200')
 //! let client = Client::new(RequestParams::default()).unwrap();
 //!
+//! // A ping request (HEAD '/')
 //! let req = PingRequest::new();
+//! 
+//! // Send the ping request and unwrap the response
 //! let response = client.request(req).send().unwrap();
 //! ```
 //!
@@ -145,7 +149,7 @@
 //! The `HttpResponse` implements `Read` so you can buffer out the raw
 //! response data.
 //! 
-//! For more details see the [`responses`](client/responses/index.html) module.
+//! For more details see the [`client`](client/index.html) and [`responses`](client/responses/index.html) module.
 //!
 //! ## Defining document types
 //!
@@ -196,6 +200,7 @@
 //! let index = Index::from("index");
 //! let id = Id::from(doc.id.to_string());
 //!
+//! // A tuple of (Index, Id, MyType) can be converted into an IndexRequest
 //! let req = IndexRequest::try_for_doc((index, id, &doc)).unwrap();
 //! # }
 //! ```
@@ -220,6 +225,7 @@
 //! let index = Index::from("index");
 //! let mapping = MyType::mapping();
 //!
+//! // A tuple of (Index, MyTypeMapping) can be converted into a MappingRequest
 //! let req = IndicesPutMappingRequest::try_for_mapping((index, mapping)).unwrap();
 //! # }
 //! ```
@@ -232,7 +238,7 @@
 //!
 //! - `elastic_reqwest` HTTP transport
 //! - `elastic_requests` API request builders
-//! - `elastic_responses` API response parser
+//! - `elastic_responses` API response parsers
 //! - `elastic_types` tools for document and mapping APIs
 //!
 //! This crate glues these libraries together with some simple assumptions
@@ -369,7 +375,7 @@ pub mod types {
     //!     id: i32,
     //!     // Mapped as a `text` field with a `keyword` subfield
     //!     title: String,
-    //!     // Mapped as a `date` with an `epoch_millis` format
+    //!     // Mapped as a `date` field with an `epoch_millis` format
     //!     timestamp: Date<EpochMillis>
     //! }
     //! # }
@@ -449,7 +455,9 @@ pub mod types {
     //! ## Define custom field data types
     //!
     //! Use traits to define your own field types and have them mapped as one of the
-    //! core datatypes:
+    //! core datatypes.
+    //! In the below example, variants of `MyEnum` will be serialised as a string,
+    //! which we map as a non-analysed `keyword` in Elasticsearch:
     //!
     //! ```
     //! # extern crate elastic;
@@ -527,6 +535,63 @@ pub mod types {
     //! # assert_eq!(expected, mapping);
     //! # }
     //! ```
+    //! 
+    //! ## Convert documents into requests
+    //! 
+    //! Documents and their mappings can be converted into index and
+    //! mapping REST API requests.
+    //! 
+    //! Convert a document and index type into an index request:
+    //! 
+    //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # extern crate serde_json;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
+    //! # #[derive(Serialize, Deserialize, ElasticType)]
+    //! # struct MyType {}
+    //! # fn get_doc() -> MyType { MyType {} }
+    //! // Get an `Index` and an instance of some `ElasticType`
+    //! let index = Index::from("my_index");
+    //! let doc = get_doc();
+    //! 
+    //! // Convert the index and document into an index request
+    //! let req = IndexRequest::try_for_doc((index, &doc)).unwrap();
+    //! # }
+    //! ```
+    //! 
+    //! Convert a document and index type into a mapping request:
+    //! 
+    //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # extern crate serde_json;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
+    //! # #[derive(Serialize, Deserialize, ElasticType)]
+    //! # struct MyType {}
+    //! # fn get_doc() -> MyType { MyType {} }
+    //! // Get an `Index` and an instance of some `ElasticType`
+    //! let index = Index::from("my_index");
+    //! let doc = get_doc();
+    //! 
+    //! // Convert the index and document into an index request
+    //! let req = IndicesPutMappingRequest::try_for_doc((index, &doc)).unwrap();
+    //! # }
+    //! ```
+    //! 
+    //! For more conversions between documents and requests, 
+    //! see the [`TryForDoc`](../client/requests/trait.TryForDoc.html) and 
+    //! [`TryForMapping`](../client/requests/trait.TryForMapping.html) traits.
 
     pub use elastic_types::{document, field, boolean, date, geo, ip, number, string, prelude};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,7 @@
 //!
 //! ```no_run
 //! # use elastic::prelude::*;
-//! let params = RequestParams::new("http://es_host:9200")
-//!     .url_param("pretty", true);
+//! let params = RequestParams::new("http://es_host:9200").url_param("pretty", true);
 //!
 //! let client = Client::new(params).unwrap();
 //! ```
@@ -88,16 +87,16 @@
 //! # let client = Client::new(params).unwrap();
 //! # let req = PingRequest::new();
 //! let response = client.request(req)
-//!     .params(|p| p.url_param("pretty", false))
-//!     .send()
-//!     .unwrap();
+//!                      .params(|p| p.url_param("pretty", false))
+//!                      .send()
+//!                      .unwrap();
 //! ```
 //! 
 //! For more details, see the [`client`](client/index.html) and [`requests`](client/requests/index.html) modules.
 //! 
 //! ## Getting Responses
 //!
-//! Call `response` on a sent request to get a `SearchResponse` or `GetResponse`:
+//! Call `response` on a sent request to get a strongly typed `SearchResponse` or `GetResponse`:
 //!
 //! ```no_run
 //! # extern crate serde;
@@ -118,8 +117,8 @@
 //! # let client = Client::new(params).unwrap();
 //! # let req = PingRequest::new();
 //! let response = client.request(req)
-//!     .send()
-//!     .and_then(|res| res.response::<SearchResponse<MyType>>());
+//!                      .send()
+//!                      .and_then(|res| res.response::<SearchResponse<MyType>>());
 //! # }
 //! ```
 //!
@@ -138,8 +137,8 @@
 //! # let client = Client::new(params).unwrap();
 //! # let req = PingRequest::new();
 //! let response = client.request(req)
-//!     .send()
-//!     .map(|res| res.raw());
+//!                      .send()
+//!                      .map(|res| res.raw());
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! // Optional
 //! extern crate serde;
-//! extern crate sede_json;
+//! extern crate serde_json;
 //! #[macro_use]
 //! extern crate serde_derive;
 //! #[macro_use]
@@ -355,6 +355,14 @@ pub mod types {
     //! document field mappings:
     //!
     //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
     //! #[derive(Serialize, Deserialize, ElasticType)]
     //! struct MyType {
     //!     // Mapped as an `integer` field
@@ -364,20 +372,51 @@ pub mod types {
     //!     // Mapped as a `date` with an `epoch_millis` format
     //!     timestamp: Date<EpochMillis>
     //! }
+    //! # }
     //! ```
     //!
     //! You can use the `Document` type wrapper to serialise the mapping for your
     //! document types:
     //!
     //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # extern crate serde_json;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
+    //! # #[derive(Serialize, Deserialize, ElasticType)]
+    //! # struct MyType {}
     //! let doc = Document::from(MyType::mapping());
     //!
     //! let mapping = serde_json::to_string(&doc).unwrap();
+    //! # }
     //! ```
     //!
     //! This will produce the following JSON:
     //!
     //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # extern crate serde_json;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # #[macro_use]
+    //! # extern crate json_str;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
+    //! # #[derive(Serialize, Deserialize, ElasticType)]
+    //! # struct MyType {
+    //! #     id: i32,
+    //! #     title: String,
+    //! #     timestamp: Date<EpochMillis>
+    //! # }
+    //! # let mapping = serde_json::to_string(&Document::from(MyType::mapping())).unwrap();
     //! # let expected = json_str!(
     //! {
     //!     "properties": {
@@ -400,6 +439,8 @@ pub mod types {
     //!     }
     //! }
     //! # );
+    //! # assert_eq!(expected, mapping);
+    //! # }
     //! ```
     //! 
     //! See the table above for a list of all supported datatypes and how to work
@@ -411,7 +452,15 @@ pub mod types {
     //! core datatypes:
     //!
     //! ```
-    //! # #[derive(Default, Serialize, Deserialize)]
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
+    //! # #[derive(Serialize, Deserialize)]
     //! enum MyEnum {
     //!     OptionA,
     //!     OptionB,
@@ -420,20 +469,52 @@ pub mod types {
     //!
     //! // Map `MyEnum` as a `keyword` in Elasticsearch, but treat it as an enum in Rust
     //! impl FieldType<DefaultKeywordMapping, KeywordFormat> for MyEnum {}
+    //! # }
     //! ```
     //! 
     //! You can then use `MyEnum` on any document type:
     //! 
     //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # use elastic::prelude::*;
+    //! # fn main() {
+    //! # #[derive(Serialize, Deserialize)]
+    //! # enum MyEnum {}
+    //! # impl FieldType<DefaultKeywordMapping, KeywordFormat> for MyEnum {}
     //! #[derive(Serialize, Deserialize, ElasticType)]
     //! struct MyType {
     //!     value: MyEnum
     //! }
+    //! # }
     //! ```
     //! 
     //! Serialising `MyType`s mapping will produce the following json:
     //! 
     //! ```
+    //! # extern crate elastic;
+    //! # #[macro_use]
+    //! # extern crate elastic_types_derive;
+    //! # extern crate serde;
+    //! # #[macro_use]
+    //! # extern crate serde_derive;
+    //! # extern crate serde_json;
+    //! # #[macro_use]
+    //! # extern crate json_str;
+    //! # use elastic::prelude::*;
+    //! # #[derive(Serialize, Deserialize)]
+    //! # enum MyEnum {}
+    //! # impl FieldType<DefaultKeywordMapping, KeywordFormat> for MyEnum {}
+    //! # #[derive(Serialize, Deserialize, ElasticType)]
+    //! # struct MyType {
+    //! #     value: MyEnum
+    //! # }
+    //! # fn main() {
+    //! # let mapping = serde_json::to_string(&Document::from(MyType::mapping())).unwrap();
     //! # let expected = json_str!(
     //! {
     //!     "properties": {
@@ -443,6 +524,8 @@ pub mod types {
     //!     }
     //! }
     //! # );
+    //! # assert_eq!(expected, mapping);
+    //! # }
     //! ```
 
     pub use elastic_types::{document, field, boolean, date, geo, ip, number, string, prelude};


### PR DESCRIPTION
Closes #172 

Working through some documentation for the `elastic` crate. The only bit I don't really like is duplicating docs between `elastic` and `elastic_types`. Feels a bit dirty...

The goal though is to get some decent documentation that describes how to use the library and how to get started customising for specific use cases.