### PR TITLE
Update to generic requests

### DIFF
--- a/benches/rust/elastic-raw/Cargo.toml
+++ b/benches/rust/elastic-raw/Cargo.toml
@@ -9,7 +9,7 @@ debug = true
 [dependencies]
 json_str = { version = "*", features = ["nightly"]}
 
-elastic = { version = "*", path = "../../../elastic" }
+elastic = { version = "*", path = "../../../elastic", features = "nightly" }
 
 lazy_static = "*"
 time = "*"

--- a/benches/rust/elastic-raw/Cargo.toml
+++ b/benches/rust/elastic-raw/Cargo.toml
@@ -9,8 +9,7 @@ debug = true
 [dependencies]
 json_str = { version = "*", features = ["nightly"]}
 
-elastic = { version = "*", path = "../../../elastic", features = "nightly" }
+elastic = { version = "*", path = "../../../elastic", features = ["nightly"] }
 
-lazy_static = "*"
 time = "*"
 stopwatch = "*"

--- a/benches/rust/elastic/Cargo.toml
+++ b/benches/rust/elastic/Cargo.toml
@@ -11,7 +11,7 @@ serde = "*"
 serde_derive = "*"
 json_str = { version = "*", features = ["nightly"]}
 
-elastic = { version = "*", path = "../../../elastic" }
+elastic = { version = "*", path = "../../../elastic", features = "nightly" }
 
 lazy_static = "*"
 time = "*"

--- a/benches/rust/elastic/Cargo.toml
+++ b/benches/rust/elastic/Cargo.toml
@@ -11,8 +11,7 @@ serde = "*"
 serde_derive = "*"
 json_str = { version = "*", features = ["nightly"]}
 
-elastic = { version = "*", path = "../../../elastic", features = "nightly" }
+elastic = { version = "*", path = "../../../elastic", features = ["nightly"] }
 
-lazy_static = "*"
 time = "*"
 stopwatch = "*"

--- a/benches/rust/elastic/src/main.rs
+++ b/benches/rust/elastic/src/main.rs
@@ -3,8 +3,6 @@
 
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate lazy_static;
 
 extern crate stopwatch;
 extern crate time;
@@ -27,19 +25,15 @@ struct BenchDoc {
     pub timestamp: Date<EpochMillis>,
 }
 
-lazy_static!(
-    static ref REQ: SearchRequest<'static> = {
-        SearchRequest::for_index_ty(
-            "bench_index", "bench_doc",
-            json_lit!({
-                query: {
-                    query_string: {
-                        query: "*"
-                    }
-                },
-                size: 10
-            }))
-        };
+static BODY: &'static str = json_lit!(
+    {
+        query: {
+            query_string: {
+                query: "*"
+            }
+        },
+        size: 10
+    }
 );
 
 fn main() {
@@ -60,7 +54,7 @@ fn main() {
     for _ in 0..runs {
         let mut sw = Stopwatch::start_new();
 
-        let req: &SearchRequest<'static> = &REQ;
+        let req = SearchRequest::for_index_ty("bench_index", "bench_doc", BODY);
         let res: SearchResponse<BenchDoc> = client.request(req)
                                                   .send()
                                                   .and_then(|res| res.response())

--- a/elastic/Cargo.toml
+++ b/elastic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic"
-version = "0.11.0"
+version = "0.10.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 keywords = ["elasticsearch", "search"]
@@ -17,8 +17,8 @@ serde = "~0.9.0"
 serde_json = "~0.9.0"
 reqwest = "~0.4.0"
 
-elastic_reqwest = { version = "~0.6.0", git = "https://github.com/elastic-rs/elastic-reqwest.git", branch = "feat/update-requests" }
-elastic_requests = { version = "~0.3.0", git = "https://github.com/elastic-rs/elastic-requests.git", branch = "feat/generic-body" }
+elastic_reqwest = "~0.6.0"
+elastic_requests = "~0.3.0"
 elastic_responses = "~0.5.0"
 elastic_types = "~0.13.0"
 

--- a/elastic/Cargo.toml
+++ b/elastic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 keywords = ["elasticsearch", "search"]
@@ -8,14 +8,17 @@ description = "A modular client for the Elasticsearch REST API."
 documentation = "https://docs.rs/elastic/"
 repository = "https://github.com/elastic-rs/elastic"
 
+[features]
+nightly = ["elastic_reqwest/nightly"]
+
 [dependencies]
 error-chain = "~0.7.0"
 serde = "~0.9.0"
 serde_json = "~0.9.0"
 reqwest = "~0.4.0"
 
-elastic_reqwest = "~0.5.0"
-elastic_requests = "~0.2.0"
+elastic_reqwest = { version = "~0.6.0", git = "https://github.com/elastic-rs/elastic-reqwest.git", branch = "feat/update-requests" }
+elastic_requests = { version = "~0.3.0", git = "https://github.com/elastic-rs/elastic-requests.git", branch = "feat/generic-body" }
 elastic_responses = "~0.5.0"
 elastic_types = "~0.13.0"
 

--- a/elastic/examples/account_sample/Cargo.toml
+++ b/elastic/examples/account_sample/Cargo.toml
@@ -3,6 +3,9 @@ name = "account-sample"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
+[features]
+nightly = ["elastic/nightly"]
+
 [dependencies]
 elastic = { version = "*", path = "../../" }
 elastic_derive = "~0.1.0"

--- a/elastic/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
+++ b/elastic/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
@@ -1,7 +1,7 @@
 use ops::Client;
 use std::io::Error as IoError;
 use serde_json::{Value, Error as JsonError};
-use elastic::client::requests::{Body, IndicesExistsRequest, IndicesCreateRequest};
+use elastic::client::requests::{IntoBody, IndicesExistsRequest, IndicesCreateRequest};
 use elastic::error::Error as ResponseError;
 
 use model;
@@ -39,8 +39,8 @@ fn exists() -> IndicesExistsRequest<'static> {
     IndicesExistsRequest::for_index(model::index::name())
 }
 
-fn put<B>(body: B) -> IndicesCreateRequest<'static>
-    where B: Into<Body<'static>>
+fn put<B>(body: B) -> IndicesCreateRequest<'static, B>
+    where B: IntoBody
 {
     IndicesCreateRequest::for_index(model::index::name(), body)
 }

--- a/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Result as IoResult, Error as IoError};
+use std::io::{Result as IoResult, Error as IoError};
 use std::fs::File;
 use std::path::Path;
 use serde_json::Value;
@@ -19,6 +19,7 @@ impl PutBulkAccounts for Client {
         let body = bulk_body(path)?;
 
         self.io.request(put(body))
+            .params(|params| params.url_param("refresh", true))
             .send()
             .and_then(|res| res.response::<Value>())?;
 
@@ -32,15 +33,10 @@ fn put<B>(body: B) -> BulkRequest<'static, B>
     BulkRequest::for_index_ty(model::index::name(), model::account::name(), body)
 }
 
-fn bulk_body<P>(path: P) -> IoResult<Vec<u8>>
+fn bulk_body<P>(path: P) -> IoResult<File>
     where P: AsRef<Path>
 {
-    let mut body = File::open(path)?;
-
-    let mut buf = Vec::new();
-    body.read_to_end(&mut buf)?;
-
-    Ok(buf)
+    File::open(path)
 }
 
 quick_error!{

--- a/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::path::Path;
 use serde_json::Value;
 use ops::Client;
-use elastic::client::requests::{Body, BulkRequest};
+use elastic::client::requests::{IntoBody, BulkRequest};
 use elastic::error::Error as ResponseError;
 
 use model;
@@ -26,8 +26,8 @@ impl PutBulkAccounts for Client {
     }
 }
 
-fn put<B>(body: B) -> BulkRequest<'static>
-    where B: Into<Body<'static>>
+fn put<B>(body: B) -> BulkRequest<'static, B>
+    where B: IntoBody
 {
     BulkRequest::for_index_ty(model::index::name(), model::account::name(), body)
 }

--- a/elastic/examples/account_sample/src/ops/queries/simple_search.rs
+++ b/elastic/examples/account_sample/src/ops/queries/simple_search.rs
@@ -1,5 +1,5 @@
 use ops::Client;
-use elastic::client::requests::{SearchRequest, Body};
+use elastic::client::requests::{SearchRequest, IntoBody};
 use elastic::client::responses::SearchResponse;
 use elastic::error::Result;
 
@@ -20,8 +20,8 @@ impl SimpleSearchQuery for Client {
     }
 }
 
-fn search<B>(body: B) -> SearchRequest<'static>
-    where B: Into<Body<'static>>
+fn search<B>(body: B) -> SearchRequest<'static, B>
+    where B: IntoBody
 {
     SearchRequest::for_index_ty(model::index::name(), model::account::name(), body)
 }

--- a/elastic/examples/typed.rs
+++ b/elastic/examples/typed.rs
@@ -87,7 +87,7 @@ fn ensure_indexed(client: &Client, doc: MyType) {
 }
 
 fn put_index(client: &Client) {
-    let req = IndicesCreateRequest::for_index(INDEX, Body::none());
+    let req = IndicesCreateRequest::for_index(INDEX, empty_body());
 
     client.request(req).send().unwrap();
 

--- a/elastic/src/client.rs
+++ b/elastic/src/client.rs
@@ -208,6 +208,20 @@ impl<'a, I, B> RequestBuilder<'a, I, B>
     ///
     /// This method will clone the `RequestParams` on the `Client` and pass
     /// them to the closure.
+    /// 
+    /// # Examples
+    /// 
+    /// Add a url param to force an index refresh:
+    /// 
+    /// ```no_run
+    /// # use elastic::prelude::*;
+    /// # let client = Client::new(RequestParams::default()).unwrap();
+    /// # fn get_req() -> PingRequest<'static> { PingRequest::new() }
+    /// client.request(get_req())
+    ///       .params(|params| params.url_param("refresh", true))
+    ///       .send()
+    ///       .unwrap();
+    /// ```
     pub fn params<F>(mut self, builder: F) -> Self
         where F: Fn(RequestParams) -> RequestParams
     {

--- a/elastic/src/impls.rs
+++ b/elastic/src/impls.rs
@@ -6,9 +6,8 @@
 //! this may be different in a future where indices only support a single
 //! document type.
 
-use serde::Serialize;
 use serde_json;
-use super::client::requests::{Index, Id, Body, IndexRequest, IndicesPutMappingRequest};
+use super::client::requests::{Index, Id, IndexRequest, IndicesPutMappingRequest};
 use super::types::prelude::*;
 
 use super::error::*;
@@ -29,7 +28,7 @@ pub trait TryForMapping<M>
     fn try_for_mapping(mapping: M) -> Result<Self>;
 }
 
-impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndexRequest<'a>
+impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndexRequest<'a, String>
     where T: DocumentType<M>,
           M: DocumentMapping
 {
@@ -42,7 +41,7 @@ impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndexRequest<'a>
     }
 }
 
-impl<'a, 'b, T, M> TryForDoc<(Index<'a>, Id<'a>, &'b T), M> for IndexRequest<'a>
+impl<'a, 'b, T, M> TryForDoc<(Index<'a>, Id<'a>, &'b T), M> for IndexRequest<'a, String>
     where T: DocumentType<M>,
           M: DocumentMapping
 {
@@ -55,17 +54,7 @@ impl<'a, 'b, T, M> TryForDoc<(Index<'a>, Id<'a>, &'b T), M> for IndexRequest<'a>
     }
 }
 
-impl<'a, 'b, T> TryForDoc<&'b T, ()> for Body<'a>
-    where T: Serialize
-{
-    fn try_for_doc(doc: &T) -> Result<Self> {
-        let doc = serde_json::to_string(&doc)?;
-
-        Ok(Self::from(doc))
-    }
-}
-
-impl<'a, M> TryForMapping<(Index<'a>, M)> for IndicesPutMappingRequest<'a>
+impl<'a, M> TryForMapping<(Index<'a>, M)> for IndicesPutMappingRequest<'a, String>
     where M: DocumentMapping
 {
     fn try_for_mapping((index, mapping): (Index<'a>, M)) -> Result<Self> {
@@ -75,7 +64,7 @@ impl<'a, M> TryForMapping<(Index<'a>, M)> for IndicesPutMappingRequest<'a>
     }
 }
 
-impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndicesPutMappingRequest<'a>
+impl<'a, 'b, T, M> TryForDoc<(Index<'a>, &'b T), M> for IndicesPutMappingRequest<'a, String>
     where T: DocumentType<M>,
           M: DocumentMapping
 {

--- a/elastic/tests/mod.rs
+++ b/elastic/tests/mod.rs
@@ -64,15 +64,3 @@ fn mapping_request_from_mapping() {
 
 	assert!(req.is_ok());
 }
-
-#[test]
-fn body_from_doc() {
-	let doc = MyType {
-		id: 1,
-		title: "A title"
-	};
-
-	let body = Body::try_for_doc(&doc);
-
-	assert!(body.is_ok());
-}


### PR DESCRIPTION
Part of #178 

This is a breaking change that makes the body buffer a generic type instead of `Cow<'a, [u8]>`, and removes the ability to convert a borrowed request into a `HttpRequest` (you can still used borrowed bodies though). This means the underlying http transport can decide what kinds of body types it will accept, rather than the request types forcing that decision.

`elastic` now accepts any type that is `Into<reqwest::Body>`, so it supports the previous types plus `File`. With stable specialisation we could add some more concrete types.

I haven't gone through the benchmarks yet (it should be much of a muchness), but will check those out and let the API simmer for a bit before merging. On the stable channel, the request body will be copied by `reqwest` if you use borrowed data, like `&[u8]` or `&str`.

Other relevant PRs:

- https://github.com/elastic-rs/elastic-requests/pull/26/
- https://github.com/elastic-rs/elastic-reqwest/pull/30/