### PR TITLE
Remove unneeded use

### DIFF
--- a/elastic/examples/typed.rs
+++ b/elastic/examples/typed.rs
@@ -17,7 +17,6 @@ extern crate elastic_derive;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
-extern crate serde_json;
 
 extern crate elastic;
 


### PR DESCRIPTION
Just removing an unneeded `serde_json` import from the `typed` sample.