### PR TITLE
Tweak Response internals

### DIFF
--- a/elastic/src/client/mod.rs
+++ b/elastic/src/client/mod.rs
@@ -410,9 +410,10 @@ pub fn into_response<T>(res: ResponseBuilder) -> Result<T>
     res.into_response()
 }
 
-/** Try convert a `ResponseBuilder` into a raw response type. */
+/** Try convert a `ResponseBuilder` into a raw http response. */
 pub fn into_raw(res: ResponseBuilder) -> Result<HttpResponse> {
     Ok(res.into_raw())
 }
 
-struct IntoResponse(RawResponse);
+/** A type that can be converted into a `ResponseBuilder` without being exposed publicly. */
+struct IntoResponseBuilder(RawResponse);

--- a/elastic/src/client/requests/mod.rs
+++ b/elastic/src/client/requests/mod.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 use elastic_reqwest::ElasticClient;
 
 use error::*;
-use client::{Client, RequestParams, IntoResponse};
+use client::{Client, RequestParams, IntoResponseBuilder};
 use client::responses::ResponseBuilder;
 
 pub use elastic_reqwest::IntoReqwestBody as IntoBody;
@@ -137,7 +137,7 @@ impl<'a, TRequest, TBody> RequestBuilder<'a, TRequest, TBody>
 
         let res = self.client.http.elastic_req(params, self.req)?;
 
-        Ok(IntoResponse(res).into())
+        Ok(IntoResponseBuilder(res).into())
     }
 }
 

--- a/elastic/src/lib.rs
+++ b/elastic/src/lib.rs
@@ -226,8 +226,7 @@ This crate is mostly a meta-package composed of a number of smaller pieces inclu
 - [`elastic_responses`][elastic-responses] API response parsers
 - [`elastic_types`][elastic-types] tools for document and mapping APIs
 
-This crate glues these libraries together with some simple assumptions
-about how they're going to be used.
+This crate glues these libraries together with some simple assumptions about how they're going to be used.
 
 # Links
 
@@ -276,6 +275,7 @@ pub mod http {
     Raw HTTP modules.
 
     These types are re-exported from `reqwest` and used in parts of `elastic`s public API.
+    They may eventually be wrapped and made implementation details.
     */
 
     pub use reqwest::header;


### PR DESCRIPTION
Just reworks the `ResponseBuilder` so it's more obvious what `IntoResponseBuilder` and `HttpResponse` are for. This doesn't affect the public API.