### PR TITLE
Refactor async sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ matrix:
         - CRATE="derive"
     - rust: stable
       env:
-        - CRATE="elastic/examples/account_sample"
-    - rust: stable
-      env:
-        - CRATE="elastic/examples/async_sample"
-    - rust: stable
-      env:
         - CRATE="elastic"
 
     - rust: nightly
@@ -29,6 +23,12 @@ matrix:
     - rust: nightly
       env:
         - CRATE="elastic"
+    - rust: nightly
+      env:
+        - CRATE="elastic/examples/account_sample"
+    - rust: nightly
+      env:
+        - CRATE="elastic/examples/async_sample"
 
 env:
   global:

--- a/elastic/examples/async_sample/Cargo.toml
+++ b/elastic/examples/async_sample/Cargo.toml
@@ -7,9 +7,6 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 elastic_requests = "*"
 elastic_responses = "*"
 
-serde = "*"
-serde_json = "*"
-
 tokio-core = "*"
 tokio-proto = "*"
 futures = "*"
@@ -18,3 +15,5 @@ memmap = "*"
 hyper = { git = "https://github.com/hyperium/hyper.git" }
 
 quick-error = "*"
+
+string_cache = { version = "*", git = "https://github.com/KodrAus/string-cache.git", branch = "chore/serde-1.0" }

--- a/elastic/examples/async_sample/README.md
+++ b/elastic/examples/async_sample/README.md
@@ -1,7 +1,10 @@
 # Async Sample
 
-This is a sample that demonstrates how you can use individual crates that make up `elastic` to build your own specific client.
+This is a sample that demonstrates how you can use individual crates that make up `elastic` to build your own specific client. It's also a bit of a playground for ideas that may find their way into the `elastic` client.
 
-It uses the [`tokio`](https://tokio.rs) branch of [`hyper`](https://hyper.rs) for asynchronously streaming a bulk request from a file. The file is memory mapped so it doesn't need a buffer allocated to hold all the bits at once.
+It uses the [`tokio`](https://tokio.rs) branch of [`hyper`](https://hyper.rs) for asynchronously streaming a bulk request from a file. The file is memory mapped so it doesn't need a buffer allocated to hold all the bits at once. There are a few other optimisations this sample uses:
+
+- The response body isn't buffered into a single contiguous slice for deserialisation. This trades memory efficiency for speed and complexity
+- The allocated field type for the `BulkResponse` is an interned string. That means duplicated values like the `index` and `type` on bulk operations are more efficient
 
 `elastic` will offer a first-class async API once `reqwest` does.

--- a/elastic/examples/async_sample/src/body.rs
+++ b/elastic/examples/async_sample/src/body.rs
@@ -1,19 +1,21 @@
+use std::cmp;
 use std::collections::VecDeque;
 use std::path::Path;
 use std::io::{Read, Error as IoError};
 
-use tokio_proto::streaming::Body;
+use tokio_proto::streaming::Body as BodyStream;
 use futures::{IntoFuture, Future, Stream, Sink, Poll, Async};
 use futures::future::lazy;
 use futures::sync::mpsc::SendError;
 use memmap::{Mmap, MmapViewSync, Protection};
-use hyper::Chunk as HttpChunk;
-use hyper::Error as HyperError;
+use hyper::{Chunk as HyperChunk, Error as HyperError};
 
 use error::*;
 
+const SLICE_SIZE: usize = 1024 * 16;
+
 /// A stream of file chunks.
-pub type FileBody = Body<FileChunk, HyperError>;
+pub type FileBody = BodyStream<FileChunk, HyperError>;
 
 /// A chunk of a file.
 pub struct FileChunk(MmapViewSync);
@@ -55,49 +57,47 @@ pub fn mapped_file<P>
     let (tx, rx) = FileBody::pair();
 
     let tx_future = lazy(move || {
-        let slices_future = map_file_to_chunks(path);
+        let slices_future = map_file_to_chunks(path).into_future();
 
         slices_future.and_then(|slices| {
-                                   let streamed = FileChunkStream(slices);
+            let streamed = FileChunkStream(slices);
 
-                                   tx.send_all(streamed).map_err(Into::into)
-                               })
+            tx.send_all(streamed).map_err(Into::into)
+        })
     });
 
-    let tx_future = tx_future.and_then(|_| Ok(()));
+    let tx_future = tx_future.map(|_| ());
 
     Ok((tx_future, rx))
 }
 
 // mmap a file and push its chunks into a queue
-fn map_file_to_chunks<P>(path: P)
-                         -> impl Future<Item = VecDeque<FileChunkResult>, Error = Error> + Send
+fn map_file_to_chunks<P>(path: P) -> Result<VecDeque<FileChunkResult>, Error>
     where P: AsRef<Path>
 {
     let file = match Mmap::open_path(path, Protection::Read) {
         Ok(file) => file,
-        Err(e) => return Err(e.into()).into_future(),
+        Err(e) => return Err(e.into()),
     };
 
     let file = file.into_view_sync();
 
     let total_len = file.len();
     if total_len == 0 {
-        return Ok(VecDeque::new()).into_future();
+        return Ok(VecDeque::new());
     }
 
-    let slice_size = 1024 * 16;
-    let num_slices = (total_len as f32 / slice_size as f32).ceil() as usize;
+    let num_slices = (total_len as f32 / SLICE_SIZE as f32).ceil() as usize;
     let mut slices = VecDeque::with_capacity(num_slices);
 
     let mut next = Some(file);
     while let Some(rest) = next {
         next = match rest.len() {
             // >1 chunk size left
-            len if len > slice_size => {
-                let (slice, rest) = match rest.split_at(slice_size) {
+            len if len > SLICE_SIZE => {
+                let (slice, rest) = match rest.split_at(SLICE_SIZE) {
                     Ok(split) => split,
-                    Err(e) => return Err(e.into()).into_future(),
+                    Err(e) => return Err(e.into()),
                 };
 
                 slices.push_back(Ok(FileChunk(slice)));
@@ -115,20 +115,31 @@ fn map_file_to_chunks<P>(path: P)
         };
     }
 
-    Ok(slices).into_future()
+    Ok(slices)
 }
 
-struct ReadableChunk {
-    buf: HttpChunk,
+/// A readable wrapper around a `Chunk`.
+///
+/// This type is basically the same as `std::io::Cursor`.
+pub struct Chunk {
+    buf: HyperChunk,
     len: usize,
     pos: usize,
 }
 
-impl Read for ReadableChunk {
+impl From<HyperChunk> for Chunk {
+    fn from(chunk: HyperChunk) -> Self {
+        Chunk {
+            len: chunk.len(),
+            pos: 0,
+            buf: chunk,
+        }
+    }
+}
+
+impl Read for Chunk {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
-        use std::cmp;
-
         let amt = cmp::min(self.pos, self.len);
         let mut chunk = &self.buf[amt..];
 
@@ -139,39 +150,34 @@ impl Read for ReadableChunk {
     }
 }
 
-type HttpBody = VecDeque<ReadableChunk>;
+type ChunkSequence = VecDeque<Chunk>;
 
-/// A writable response body where chunks can be pushed in order.
-pub struct HttpReadBodyBuilder(HttpBody);
+/// A builder for a sequence of chunks.
+pub struct ChunkBodyBuilder(ChunkSequence);
 
 /// A readable response body where bytes are read from all chunks without exposing them directly.
-pub struct HttpReadBody(HttpBody);
+pub struct ChunkBody(ChunkSequence);
 
-impl HttpReadBodyBuilder {
+impl ChunkBodyBuilder {
     pub fn new() -> Self {
-        HttpReadBodyBuilder(HttpBody::new())
+        ChunkBodyBuilder(ChunkSequence::new())
     }
 
-    pub fn push(&mut self, chunk: HttpChunk) {
-        let len = chunk.len();
-
-        self.0
-            .push_back(ReadableChunk {
-                           len: len,
-                           pos: 0,
-                           buf: chunk,
-                       });
+    pub fn append<I>(&mut self, chunk: I)
+        where I: Into<Chunk>
+    {
+        self.0.push_back(chunk.into());
     }
 
-    pub fn build(self) -> HttpReadBody {
+    pub fn build(self) -> ChunkBody {
         let mut chunks = self.0;
         chunks.shrink_to_fit();
 
-        HttpReadBody(chunks)
+        ChunkBody(chunks)
     }
 }
 
-impl Read for HttpReadBody {
+impl Read for ChunkBody {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
         let mut pop = false;
 
@@ -179,7 +185,7 @@ impl Read for HttpReadBody {
             let read = chunk.read(buf)?;
 
             if chunk.pos >= chunk.len {
-                pop = true
+                pop = true;
             }
 
             read

--- a/elastic/examples/async_sample/src/body.rs
+++ b/elastic/examples/async_sample/src/body.rs
@@ -1,35 +1,38 @@
 use std::collections::VecDeque;
 use std::path::Path;
-use std::io::Error as IoError;
+use std::io::{Read, Error as IoError};
 
 use tokio_proto::streaming::Body;
-use futures::{Future, Stream, Sink, Poll, Async};
-use futures::future::{ok, err, lazy, FutureResult};
+use futures::{IntoFuture, Future, Stream, Sink, Poll, Async};
+use futures::future::lazy;
 use futures::sync::mpsc::SendError;
 use memmap::{Mmap, MmapViewSync, Protection};
+use hyper::Chunk as HttpChunk;
 use hyper::Error as HyperError;
 
 use error::*;
 
 /// A stream of file chunks.
-pub type MappedFileBody = Body<Chunk, HyperError>;
+pub type FileBody = Body<FileChunk, HyperError>;
 
 /// A chunk of a file.
-pub struct Chunk(MmapViewSync);
+pub struct FileChunk(MmapViewSync);
 
-impl AsRef<[u8]> for Chunk {
+impl AsRef<[u8]> for FileChunk {
     fn as_ref(&self) -> &[u8] {
+        // Safe because the file is immutable
         unsafe { self.0.as_slice() }
     }
 }
 
-pub type ChunkResult = Result<Chunk, HyperError>;
+// Plumbing for streaming a mapped file in chunks
+pub type FileChunkResult = Result<FileChunk, HyperError>;
 
-struct ChunkStream(VecDeque<ChunkResult>);
+struct FileChunkStream(VecDeque<FileChunkResult>);
 
-impl Stream for ChunkStream {
-    type Item = ChunkResult;
-    type Error = SendError<ChunkResult>;
+impl Stream for FileChunkStream {
+    type Item = FileChunkResult;
+    type Error = SendError<FileChunkResult>;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         if let Some(slice) = self.0.pop_front() {
@@ -46,46 +49,44 @@ impl Stream for ChunkStream {
 /// The second item is the async body to use in the request.
 pub fn mapped_file<P>
     (path: P)
-     -> Result<(Box<Future<Item = (), Error = RequestError> + Send>, MappedFileBody), IoError>
+     -> Result<(impl Future<Item = (), Error = Error> + Send, FileBody), IoError>
     where P: AsRef<Path> + Send + 'static
 {
-    let (tx, rx) = MappedFileBody::pair();
+    let (tx, rx) = FileBody::pair();
 
     let tx_future = lazy(move || {
         let slices_future = map_file_to_chunks(path);
 
         slices_future.and_then(|slices| {
-                                   let streamed = ChunkStream(slices);
+                                   let streamed = FileChunkStream(slices);
 
-                                   tx.send_all(streamed).map_err(|e| e.into())
+                                   tx.send_all(streamed).map_err(Into::into)
                                })
     });
 
-    let tx_future = tx_future.and_then(|_| ok(()));
+    let tx_future = tx_future.and_then(|_| Ok(()));
 
-    Ok((tx_future.boxed(), rx))
+    Ok((tx_future, rx))
 }
 
-fn map_file_to_chunks<P>(path: P) -> FutureResult<VecDeque<ChunkResult>, RequestError>
+// mmap a file and push its chunks into a queue
+fn map_file_to_chunks<P>(path: P) -> impl Future<Item = VecDeque<FileChunkResult>, Error = Error> + Send
     where P: AsRef<Path>
 {
     let file = match Mmap::open_path(path, Protection::Read) {
         Ok(file) => file,
-        Err(e) => return err(e.into()),
+        Err(e) => return Err(e.into()).into_future(),
     };
 
     let file = file.into_view_sync();
 
     let total_len = file.len();
-
     if total_len == 0 {
-        return ok(VecDeque::new());
+        return Ok(VecDeque::new()).into_future();
     }
 
     let slice_size = 1024 * 16;
-
     let num_slices = (total_len as f32 / slice_size as f32).ceil() as usize;
-
     let mut slices = VecDeque::with_capacity(num_slices);
 
     let mut next = Some(file);
@@ -95,10 +96,10 @@ fn map_file_to_chunks<P>(path: P) -> FutureResult<VecDeque<ChunkResult>, Request
             len if len > slice_size => {
                 let (slice, rest) = match rest.split_at(slice_size) {
                     Ok(split) => split,
-                    Err(e) => return err(e.into()),
+                    Err(e) => return Err(e.into()).into_future(),
                 };
 
-                slices.push_back(Ok(Chunk(slice)));
+                slices.push_back(Ok(FileChunk(slice)));
 
                 Some(rest)
             }
@@ -106,12 +107,89 @@ fn map_file_to_chunks<P>(path: P) -> FutureResult<VecDeque<ChunkResult>, Request
             0 => None,
             // Last chunk
             _ => {
-                slices.push_back(Ok(Chunk(rest)));
+                slices.push_back(Ok(FileChunk(rest)));
 
                 None
             }
         };
     }
 
-    ok(slices)
+    Ok(slices).into_future()
+}
+
+struct ReadableChunk {
+    buf: HttpChunk,
+    len: usize,
+    pos: usize,
+}
+
+impl Read for ReadableChunk {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        use std::cmp;
+
+        let amt = cmp::min(self.pos, self.len);
+        let mut chunk = &self.buf[amt..];
+
+        let read = chunk.read(buf)?;
+        self.pos += read;
+
+        Ok(read)
+    }
+}
+
+type HttpBody = VecDeque<ReadableChunk>;
+
+/// A writable response body where chunks can be pushed in order.
+pub struct HttpReadBodyBuilder(HttpBody);
+
+/// A readable response body where bytes are read from all chunks without exposing them directly.
+pub struct HttpReadBody(HttpBody);
+
+impl HttpReadBodyBuilder {
+    pub fn new() -> Self {
+        HttpReadBodyBuilder(HttpBody::new())
+    }
+
+    pub fn push(&mut self, chunk: HttpChunk) {
+        let len = chunk.len();
+
+        self.0.push_back(ReadableChunk {
+            len: len,
+            pos: 0,
+            buf: chunk
+        });
+    }
+
+    pub fn build(self) -> HttpReadBody {
+        let mut chunks = self.0;
+        chunks.shrink_to_fit();
+
+        HttpReadBody(chunks)
+    }
+}
+
+impl Read for HttpReadBody {
+    fn read(&mut self, buf: &mut[u8]) -> Result<usize, IoError> {
+        let mut pop = false;
+        
+        let read = if let Some(mut chunk) = self.0.front_mut() {
+            let read = chunk.read(buf)?;
+
+            if chunk.pos >= chunk.len {
+                pop = true
+            }
+
+            read
+        }
+        else {
+            0
+        };
+
+        if pop {
+            self.0.pop_front();
+        }
+
+        Ok(read)
+    }
 }

--- a/elastic/examples/async_sample/src/body.rs
+++ b/elastic/examples/async_sample/src/body.rs
@@ -70,7 +70,8 @@ pub fn mapped_file<P>
 }
 
 // mmap a file and push its chunks into a queue
-fn map_file_to_chunks<P>(path: P) -> impl Future<Item = VecDeque<FileChunkResult>, Error = Error> + Send
+fn map_file_to_chunks<P>(path: P)
+                         -> impl Future<Item = VecDeque<FileChunkResult>, Error = Error> + Send
     where P: AsRef<Path>
 {
     let file = match Mmap::open_path(path, Protection::Read) {
@@ -154,11 +155,12 @@ impl HttpReadBodyBuilder {
     pub fn push(&mut self, chunk: HttpChunk) {
         let len = chunk.len();
 
-        self.0.push_back(ReadableChunk {
-            len: len,
-            pos: 0,
-            buf: chunk
-        });
+        self.0
+            .push_back(ReadableChunk {
+                           len: len,
+                           pos: 0,
+                           buf: chunk,
+                       });
     }
 
     pub fn build(self) -> HttpReadBody {
@@ -170,9 +172,9 @@ impl HttpReadBodyBuilder {
 }
 
 impl Read for HttpReadBody {
-    fn read(&mut self, buf: &mut[u8]) -> Result<usize, IoError> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
         let mut pop = false;
-        
+
         let read = if let Some(mut chunk) = self.0.front_mut() {
             let read = chunk.read(buf)?;
 
@@ -181,8 +183,7 @@ impl Read for HttpReadBody {
             }
 
             read
-        }
-        else {
+        } else {
             0
         };
 

--- a/elastic/examples/async_sample/src/error.rs
+++ b/elastic/examples/async_sample/src/error.rs
@@ -1,19 +1,23 @@
 use std::io::Error as IoError;
 use futures::sync::mpsc::SendError;
 use hyper::Error as HyperError;
+use elastic_responses::error::ResponseError;
 
 use body;
 
 quick_error!{
     #[derive(Debug)]
-    pub enum RequestError {
+    pub enum Error {
         Io(err: IoError) {
             from()
         }
-        Body(err: SendError<body::ChunkResult>) {
+        Hyper(err: HyperError) {
             from()
         }
-        Request(err: HyperError) {
+        Response(err: ResponseError) {
+            from()
+        }
+        FileBody(err: SendError<body::FileChunkResult>) {
             from()
         }
     }

--- a/elastic/examples/async_sample/src/main.rs
+++ b/elastic/examples/async_sample/src/main.rs
@@ -78,7 +78,7 @@ fn send_request(url: &'static str, client: &Client<HttpConnector, RequestBody>, 
 
 // Read the response body into a queue of chunks
 fn buffer_response_body(res: hyper::client::Response) -> impl Future<Item = (u16, ResponseBody), Error = Error> {
-    let status: u16 = (*res.status()).into();
+    let status: u16 = res.status().into();
 
     // Buffer the response chunks into a synchronously readable sequence
     let buffer_body = res.body()

--- a/elastic/examples/async_sample/src/main.rs
+++ b/elastic/examples/async_sample/src/main.rs
@@ -45,18 +45,24 @@ fn main() {
 
     // Create an IO core and thread pool
     let mut core = Core::new().unwrap();
-    let pool = CpuPoolBuilder::new().pool_size(4).name_prefix("pool-thread").create();
+    let pool = CpuPoolBuilder::new()
+        .pool_size(4)
+        .name_prefix("pool-thread")
+        .create();
 
     // Create a `hyper` client
     let client = hyper::client::Config::default()
         .body::<RequestBody>()
         .build(&core.handle());
-    
+
     let request = send_request(url, &client, pool);
     core.run(request).unwrap();
 }
 
-fn send_request(url: &'static str, client: &Client<HttpConnector, RequestBody>, pool: CpuPool) -> impl Future<Item = BulkResponse, Error = Error> {
+fn send_request(url: &'static str,
+                client: &Client<HttpConnector, RequestBody>,
+                pool: CpuPool)
+                -> impl Future<Item = BulkResponse, Error = Error> {
     // Get a future to buffer a bulk file
     let (buffer_request_body, body) = body::mapped_file("./data/accounts.json").unwrap();
     let buffer_request_body = pool.spawn(buffer_request_body);
@@ -65,7 +71,9 @@ fn send_request(url: &'static str, client: &Client<HttpConnector, RequestBody>, 
     let req = BulkRequest::for_index_ty("bulk-async", "bulk-ty", body);
 
     // Send the request
-    let send_request = client.request(hyper_req::build(&url, req)).map_err(Into::into);
+    let send_request = client
+        .request(hyper_req::build(&url, req))
+        .map_err(Into::into);
 
     // Read and desrialise the response
     let read_response = send_request
@@ -73,27 +81,32 @@ fn send_request(url: &'static str, client: &Client<HttpConnector, RequestBody>, 
         .and_then(move |res| pool.spawn(deserialise_response(res)));
 
     // Join the future to buffer the request body with the future to send the request
-    buffer_request_body.join(read_response).and_then(move |(_, res)| Ok(res))
+    buffer_request_body
+        .join(read_response)
+        .and_then(move |(_, res)| Ok(res))
 }
 
 // Read the response body into a queue of chunks
-fn buffer_response_body(res: hyper::client::Response) -> impl Future<Item = (u16, ResponseBody), Error = Error> {
+fn buffer_response_body(res: hyper::client::Response)
+                        -> impl Future<Item = (u16, ResponseBody), Error = Error> {
     let status: u16 = res.status().into();
 
     // Buffer the response chunks into a synchronously readable sequence
-    let buffer_body = res.body()
-        .fold::<_, _, Result<_, hyper::Error>>(body::HttpReadBodyBuilder::new(), |mut buf, chunk| {
-            buf.push(chunk);
-            Ok(buf)
-        });
+    res.body()
+        .fold(body::HttpReadBodyBuilder::new(), concat_chunks)
+        .and_then(move |buf| Ok((status, buf.build())))
+        .map_err(Into::into)
+}
 
-    buffer_body.and_then(move |buf| {
-        Ok((status, buf.build()))
-    })
-    .map_err(Into::into)
+fn concat_chunks(mut buf: body::HttpReadBodyBuilder,
+                 chunk: hyper::Chunk)
+                 -> Result<body::HttpReadBodyBuilder, hyper::Error> {
+    buf.push(chunk);
+    Ok(buf)
 }
 
 // Deserialise the queue of chunks as a BulkResponse
-fn deserialise_response((status, mut buf): (u16, ResponseBody)) -> impl Future<Item = BulkResponse, Error = Error> {
+fn deserialise_response((status, mut buf): (u16, ResponseBody))
+                        -> impl Future<Item = BulkResponse, Error = Error> {
     lazy(move || parse::<BulkResponse>().from_reader(status, &mut buf)).map_err(Into::into)
 }


### PR DESCRIPTION
Reworks the async sample a bit to avoid copying the response when deserialising. Also uses `string-cache` for interning the `index` and `type` fields in the bulk response.

Avoiding the response copy is actually slower than just buffering into a `Vec<u8>`, but is much more memory efficient.