### PR TITLE
More async sample

### DIFF
--- a/elastic/examples/async_sample/src/body/mod.rs
+++ b/elastic/examples/async_sample/src/body/mod.rs
@@ -1,0 +1,2 @@
+pub mod request;
+pub mod response;

--- a/elastic/examples/async_sample/src/body/response.rs
+++ b/elastic/examples/async_sample/src/body/response.rs
@@ -1,0 +1,89 @@
+use std::cmp;
+use std::collections::VecDeque;
+use std::io::{Read, Error as IoError};
+
+use futures::{Sink, Poll, Async};
+use hyper::Chunk as HyperChunk;
+
+/// A readable wrapper around a `Chunk`.
+///
+/// This type is basically the same as `std::io::Cursor`.
+pub struct Chunk {
+    buf: HyperChunk,
+    len: usize,
+    pos: usize,
+}
+
+impl From<HyperChunk> for Chunk {
+    fn from(chunk: HyperChunk) -> Self {
+        Chunk {
+            len: chunk.len(),
+            pos: 0,
+            buf: chunk,
+        }
+    }
+}
+
+impl Read for Chunk {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        let amt = cmp::min(self.pos, self.len);
+        let mut chunk = &self.buf[amt..];
+
+        let read = chunk.read(buf)?;
+        self.pos += read;
+
+        Ok(read)
+    }
+}
+
+type ChunkSequence = VecDeque<Chunk>;
+
+/// A builder for a sequence of chunks.
+pub struct ChunkBodyBuilder(ChunkSequence);
+
+/// A readable response body where bytes are read from all chunks without exposing them directly.
+pub struct ChunkBody(ChunkSequence);
+
+impl ChunkBodyBuilder {
+    pub fn new() -> Self {
+        ChunkBodyBuilder(ChunkSequence::new())
+    }
+
+    pub fn append<I>(&mut self, chunk: I)
+        where I: Into<Chunk>
+    {
+        self.0.push_back(chunk.into());
+    }
+
+    pub fn build(self) -> ChunkBody {
+        let mut chunks = self.0;
+        chunks.shrink_to_fit();
+
+        ChunkBody(chunks)
+    }
+}
+
+impl Read for ChunkBody {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        let mut pop = false;
+
+        let read = if let Some(mut chunk) = self.0.front_mut() {
+            let read = chunk.read(buf)?;
+
+            if chunk.pos >= chunk.len {
+                pop = true;
+            }
+
+            read
+        } else {
+            0
+        };
+
+        if pop {
+            self.0.pop_front();
+        }
+
+        Ok(read)
+    }
+}

--- a/elastic/examples/async_sample/src/error.rs
+++ b/elastic/examples/async_sample/src/error.rs
@@ -17,7 +17,7 @@ quick_error!{
         Response(err: ResponseError) {
             from()
         }
-        FileBody(err: SendError<body::FileChunkResult>) {
+        FileBody(err: SendError<body::request::FileChunkResult>) {
             from()
         }
     }

--- a/elastic/examples/async_sample/src/main.rs
+++ b/elastic/examples/async_sample/src/main.rs
@@ -33,7 +33,7 @@ use hyper::client::HttpConnector;
 
 use error::Error;
 
-type RequestBody = body::FileBody;
+type RequestBody = body::request::FileBody;
 
 type AllocatedField = string_cache::DefaultAtom;
 type BulkResponse = elastic_responses::BulkErrorsResponse<AllocatedField, AllocatedField, String>;
@@ -64,21 +64,21 @@ fn send_request(url: &'static str,
                 pool: CpuPool)
                 -> impl Future<Item = BulkResponse, Error = Error> {
     // Get a future to buffer a bulk file
-    let (buffer_request_body, request_body) = body::mapped_file("./data/accounts.json").unwrap();
+    let (buffer_request_body, request_body) = body::request::mapped_file("./data/accounts.json").unwrap();
     let buffer_request_body = pool.spawn(buffer_request_body);
 
     // Build a Bulk request
-    let req = BulkRequest::for_index_ty("bulk-async", "bulk-ty", request_body);
+    let request = BulkRequest::for_index_ty("bulk-async", "bulk-ty", request_body);
 
     // Send the request
     let send_request = client
-        .request(hyper_req::build(&url, req))
+        .request(hyper_req::build(&url, request))
         .map_err(Into::into);
 
     // Buffer the response chunks into a synchronously readable sequence
     let read_response = send_request.and_then(move |response| {
         let status: u16 = response.status().into();
-        let chunks = body::ChunkBodyBuilder::new();
+        let chunks = body::response::ChunkBodyBuilder::new();
 
         response.body()
             .fold(chunks, concat_chunks)
@@ -101,9 +101,9 @@ fn send_request(url: &'static str,
         .map(move |(_, response)| response)
 }
 
-fn concat_chunks(mut chunks: body::ChunkBodyBuilder,
+fn concat_chunks(mut chunks: body::response::ChunkBodyBuilder,
                  chunk: hyper::Chunk)
-                 -> Result<body::ChunkBodyBuilder, hyper::Error> {
+                 -> Result<body::response::ChunkBodyBuilder, hyper::Error> {
     chunks.append(chunk);
     Ok(chunks)
 }


### PR DESCRIPTION
Splits the `body` module into `request` and `response`. Nothing much to see here.