### PR TITLE
add a sample for IsOk

### DIFF
--- a/elastic/examples/custom_response.rs
+++ b/elastic/examples/custom_response.rs
@@ -1,0 +1,72 @@
+//! A custom search response type.
+//!
+//! NOTE: This sample expects you have a node running on `localhost:9200`.
+//!
+//! This sample demonstrates creating a custom `SearchResponse` type that can be used with
+//! the `filter_path` query parameter to only return the matched hits.
+
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
+extern crate elastic;
+
+use serde_json::Value;
+use elastic::prelude::*;
+use elastic::client::responses::parse::{IsOk, ParseResponseError, ResponseBody, HttpResponseHead, MaybeOkResponse, Unbuffered};
+
+#[derive(Deserialize, Debug)]
+struct SearchResponse {
+    hits: Hits
+}
+
+#[derive(Deserialize, Debug)]
+struct Hits {
+    hits: Vec<Hit>
+}
+
+#[derive(Deserialize, Debug)]
+struct Hit {
+    #[serde(rename = "_source")]
+    pub source: Value,
+}
+
+// Implement `IsOk` for our custom `SearchResponse` so it can be used in the call to `into_response`.
+impl IsOk for SearchResponse {
+    fn is_ok<B: ResponseBody>(head: HttpResponseHead, body: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
+        match head.status() {
+            200...299 => Ok(MaybeOkResponse::ok(body)),
+            _ => Ok(MaybeOkResponse::err(body)),
+        }
+    }
+}
+
+fn main() {
+    // A reqwest HTTP client and default parameters.
+    // The `params` includes the base node url (http://localhost:9200).
+    let client = Client::new(RequestParams::default()).unwrap();
+
+    let query = json!({
+        "query": {
+            "query_string": {
+                "query": "*"
+            }
+        }
+    });
+
+    // Send the request and process the response.
+    let res = client
+        .request(SearchRequest::new(query.to_string()))
+        .params(|q| q.url_param("filter_path", "hits.hits._source"))
+        .send()
+        .and_then(into_response::<SearchResponse>)
+        .unwrap();
+
+    // Iterate through the hits in the response.
+    for hit in &res.hits.hits {
+        println!("{:?}", hit);
+    }
+
+    println!("{:?}", res);
+}

--- a/elastic/examples/custom_response.rs
+++ b/elastic/examples/custom_response.rs
@@ -14,7 +14,7 @@ extern crate elastic;
 
 use serde_json::Value;
 use elastic::prelude::*;
-use elastic::client::responses::parse::{IsOk, ParseResponseError, ResponseBody, HttpResponseHead, MaybeOkResponse, Unbuffered};
+use elastic::client::responses::parse::*;
 
 #[derive(Deserialize, Debug)]
 struct SearchResponse {

--- a/elastic/src/client/responses/parse.rs
+++ b/elastic/src/client/responses/parse.rs
@@ -93,3 +93,4 @@ See the [`IsOk`][IsOk] trait for more details.
 
 pub use elastic_reqwest::res::parsing::{HttpResponseHead, IsOk, ResponseBody, MaybeOkResponse,
                                         MaybeBufferedResponse, Unbuffered, Buffered};
+pub use elastic_reqwest::res::error::ParseResponseError;


### PR DESCRIPTION
Adds a sample for `IsOk` and re-exports the parse error in the module that actually used it.