### PR TITLE
Make request builder consistent

### DIFF
--- a/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -23,8 +23,8 @@ impl PutBulkAccounts for Client {
         let res = self.io
             .request(req)
             .params(|params| params.url_param("refresh", true))
-            .send()
-            .and_then(into_response::<BulkErrorsResponse>)?;
+            .send()?
+            .into_response::<BulkErrorsResponse>()?;
 
         if res.is_err() {
             return Err(res.items.into());

--- a/elastic/examples/custom_response.rs
+++ b/elastic/examples/custom_response.rs
@@ -18,12 +18,12 @@ use elastic::client::responses::parse::*;
 
 #[derive(Deserialize, Debug)]
 struct SearchResponse {
-    hits: Hits
+    hits: Hits,
 }
 
 #[derive(Deserialize, Debug)]
 struct Hits {
-    hits: Vec<Hit>
+    hits: Vec<Hit>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -34,7 +34,9 @@ struct Hit {
 
 // Implement `IsOk` for our custom `SearchResponse` so it can be used in the call to `into_response`.
 impl IsOk for SearchResponse {
-    fn is_ok<B: ResponseBody>(head: HttpResponseHead, body: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
+    fn is_ok<B: ResponseBody>(head: HttpResponseHead,
+                              body: Unbuffered<B>)
+                              -> Result<MaybeOkResponse<B>, ParseResponseError> {
         match head.status() {
             200...299 => Ok(MaybeOkResponse::ok(body)),
             _ => Ok(MaybeOkResponse::err(body)),

--- a/elastic/src/client/mod.rs
+++ b/elastic/src/client/mod.rs
@@ -358,6 +358,8 @@ Create a `Client` for an Elasticsearch node at `es_host:9200`:
 let params = RequestParams::new("http://es_host:9200").url_param("pretty", true);
 
 let client = Client::new(params).unwrap();
+
+[RequestBuilder]: requests/index.html
 ```
 */
 pub struct Client {
@@ -392,6 +394,8 @@ impl Client {
     ```
     
     See [`RequestParams`][RequestParams] for more configuration options.
+
+    [RequestParams]: struct.RequestParams.html
     */
     pub fn new(params: RequestParams) -> Result<Self> {
         let client = HttpClient::new()?;

--- a/elastic/src/client/requests/create_index.rs
+++ b/elastic/src/client/requests/create_index.rs
@@ -1,7 +1,7 @@
 use error::*;
-use client::{into_response, Client};
+use client::Client;
 use client::requests::{empty_body, DefaultBody, IntoBody, Index, IndicesCreateRequest,
-                       RequestBuilder};
+                       RequestBuilder, RawRequestBuilder};
 use client::responses::CommandResponse;
 
 /** 
@@ -74,10 +74,9 @@ impl Client {
     [types-mod]: ../types/index.html
     [documents-mod]: ../types/document/index.html
     */
-    pub fn create_index<'a>
-        (&'a self,
-         index: Index<'static>)
-         -> RequestBuilder<'a, CreateIndexRequestBuilder<DefaultBody>, DefaultBody> {
+    pub fn create_index<'a>(&'a self,
+                            index: Index<'static>)
+                            -> RequestBuilder<'a, CreateIndexRequestBuilder<DefaultBody>> {
         RequestBuilder::new(&self,
                             None,
                             CreateIndexRequestBuilder {
@@ -105,7 +104,7 @@ Call [`Client.create_index`][Client.create_index] to get a `RequestBuilder` for 
 [Client.create_index]: ../struct.Client.html#method.create_index
 [docs-create-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
 */
-impl<'a, TBody> RequestBuilder<'a, CreateIndexRequestBuilder<TBody>, TBody>
+impl<'a, TBody> RequestBuilder<'a, CreateIndexRequestBuilder<TBody>>
     where TBody: IntoBody
 {
     /** 
@@ -115,7 +114,7 @@ impl<'a, TBody> RequestBuilder<'a, CreateIndexRequestBuilder<TBody>, TBody>
     */
     pub fn body<TNewBody>(self,
                           body: TNewBody)
-                          -> RequestBuilder<'a, CreateIndexRequestBuilder<TNewBody>, TNewBody>
+                          -> RequestBuilder<'a, CreateIndexRequestBuilder<TNewBody>>
         where TNewBody: IntoBody
     {
         RequestBuilder::new(self.client,
@@ -130,9 +129,9 @@ impl<'a, TBody> RequestBuilder<'a, CreateIndexRequestBuilder<TBody>, TBody>
     pub fn send(self) -> Result<CommandResponse> {
         let req = self.req.into_request();
 
-        RequestBuilder::new(self.client, self.params, req)
-            .send_raw()
-            .and_then(into_response)
+        RequestBuilder::new(self.client, self.params, RawRequestBuilder::new(req))
+            .send_raw()?
+            .into_response()
     }
 }
 

--- a/elastic/src/client/requests/get_document.rs
+++ b/elastic/src/client/requests/get_document.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 use serde::de::DeserializeOwned;
 
 use error::*;
-use client::{into_response, Client};
-use client::requests::{DefaultBody, Index, Type, Id, GetRequest, RequestBuilder};
+use client::Client;
+use client::requests::{Index, Type, Id, GetRequest, RequestBuilder, RawRequestBuilder};
 use client::responses::GetResponse;
 use types::document::DocumentType;
 
@@ -79,11 +79,10 @@ impl Client {
     [types-mod]: ../types/index.html
     [documents-mod]: ../types/document/index.html
     */
-    pub fn get_document<'a, TDocument>
-        (&'a self,
-         index: Index<'static>,
-         id: Id<'static>)
-         -> RequestBuilder<'a, GetRequestBuilder<TDocument>, DefaultBody>
+    pub fn get_document<'a, TDocument>(&'a self,
+                                       index: Index<'static>,
+                                       id: Id<'static>)
+                                       -> RequestBuilder<'a, GetRequestBuilder<TDocument>>
         where TDocument: DeserializeOwned + DocumentType
     {
         let ty = TDocument::name().into();
@@ -115,7 +114,7 @@ Call [`Client.get_document`][Client.get_document] to get a `RequestBuilder` for 
 [Client.get_document]: ../struct.Client.html#method.get_document
 [docs-get]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
 */
-impl<'a, TDocument> RequestBuilder<'a, GetRequestBuilder<TDocument>, DefaultBody>
+impl<'a, TDocument> RequestBuilder<'a, GetRequestBuilder<TDocument>>
     where TDocument: DeserializeOwned + DocumentType
 {
     /** Set the type for the get request. */
@@ -130,9 +129,9 @@ impl<'a, TDocument> RequestBuilder<'a, GetRequestBuilder<TDocument>, DefaultBody
     pub fn send(self) -> Result<GetResponse<TDocument>> {
         let req = self.req.into_request();
 
-        RequestBuilder::new(self.client, self.params, req)
-            .send_raw()
-            .and_then(into_response)
+        RequestBuilder::new(self.client, self.params, RawRequestBuilder::new(req))
+            .send_raw()?
+            .into_response()
     }
 }
 

--- a/elastic/src/client/requests/index_document.rs
+++ b/elastic/src/client/requests/index_document.rs
@@ -2,8 +2,8 @@ use serde_json;
 use serde::Serialize;
 
 use error::*;
-use client::{into_response, Client};
-use client::requests::{Index, Type, Id, IndexRequest, RequestBuilder};
+use client::Client;
+use client::requests::{Index, Type, Id, IndexRequest, RequestBuilder, RawRequestBuilder};
 use client::responses::IndexResponse;
 use types::document::DocumentType;
 
@@ -60,12 +60,11 @@ impl Client {
     [types-mod]: ../types/index.html
     [documents-mod]: ../types/document/index.html
     */
-    pub fn index_document<'a, TDocument>
-        (&'a self,
-         index: Index<'static>,
-         id: Id<'static>,
-         doc: TDocument)
-         -> RequestBuilder<'a, IndexRequestBuilder<TDocument>, TDocument>
+    pub fn index_document<'a, TDocument>(&'a self,
+                                         index: Index<'static>,
+                                         id: Id<'static>,
+                                         doc: TDocument)
+                                         -> RequestBuilder<'a, IndexRequestBuilder<TDocument>>
         where TDocument: Serialize + DocumentType
     {
         let ty = TDocument::name().into();
@@ -101,7 +100,7 @@ Call [`Client.index_document`][Client.index_document] to get a `RequestBuilder` 
 [Client.index_document]: ../struct.Client.html#method.index_document
 [docs-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
 */
-impl<'a, TDocument> RequestBuilder<'a, IndexRequestBuilder<TDocument>, TDocument>
+impl<'a, TDocument> RequestBuilder<'a, IndexRequestBuilder<TDocument>>
     where TDocument: Serialize
 {
     /** Set the type for the index request. */
@@ -116,9 +115,9 @@ impl<'a, TDocument> RequestBuilder<'a, IndexRequestBuilder<TDocument>, TDocument
     pub fn send(self) -> Result<IndexResponse> {
         let req = self.req.into_request()?;
 
-        RequestBuilder::new(self.client, self.params, req)
-            .send_raw()
-            .and_then(into_response)
+        RequestBuilder::new(self.client, self.params, RawRequestBuilder::new(req))
+            .send_raw()?
+            .into_response()
     }
 }
 

--- a/elastic/src/client/requests/mod.rs
+++ b/elastic/src/client/requests/mod.rs
@@ -218,7 +218,7 @@ mod tests {
     fn request_builder_params() {
         let client = Client::new(RequestParams::new("http://eshost:9200")).unwrap();
 
-        let req = RequestBuilder::<_, ()>::new(&client, None, PingRequest::new())
+        let req = RequestBuilder::new(&client, None, PingRequest::new())
             .params(|p| p.url_param("pretty", true))
             .params(|p| p.url_param("refresh", true));
 

--- a/elastic/src/client/requests/mod.rs
+++ b/elastic/src/client/requests/mod.rs
@@ -40,11 +40,38 @@ A builder for a raw request.
 
 This structure wraps up a concrete REST API request type and lets you adjust parameters before sending it.
 */
-pub struct RequestBuilder<'a, TRequest, TBody> {
+pub struct RequestBuilder<'a, TRequest> {
     client: &'a Client,
     params: Option<RequestParams>,
     req: TRequest,
-    _marker: PhantomData<TBody>,
+}
+
+/**
+A builder for a raw [`Client.request`][Client.request]. 
+
+[Client.request]: ../struct.Client.html#method.request
+*/
+pub struct RawRequestBuilder<TRequest, TBody> {
+    inner: TRequest,
+    _marker: PhantomData<TBody>
+}
+
+impl<TRequest, TBody> RawRequestBuilder<TRequest, TBody> {
+    fn new(req: TRequest) -> Self {
+        RawRequestBuilder {
+            inner: req,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<TRequest, TBody> Into<HttpRequest<'static, TBody>> for RawRequestBuilder<TRequest, TBody>
+    where TRequest: Into<HttpRequest<'static, TBody>>,
+          TBody: IntoBody
+{
+    fn into(self) -> HttpRequest<'static, TBody> {
+        self.inner.into()
+    }
 }
 
 impl Client {
@@ -79,26 +106,23 @@ impl Client {
     */
     pub fn request<'a, TRequest, TBody>(&'a self,
                                         req: TRequest)
-                                        -> RequestBuilder<'a, TRequest, TBody>
+                                        -> RequestBuilder<'a, RawRequestBuilder<TRequest, TBody>>
         where TRequest: Into<HttpRequest<'static, TBody>>,
               TBody: IntoBody
     {
-        RequestBuilder::new(&self, None, req)
+        RequestBuilder::new(&self, None, RawRequestBuilder::new(req))
     }
 }
 
-impl<'a, TRequest, TBody> RequestBuilder<'a, TRequest, TBody> {
+impl<'a, TRequest> RequestBuilder<'a, TRequest> {
     fn new(client: &'a Client, params: Option<RequestParams>, req: TRequest) -> Self {
         RequestBuilder {
             client: client,
             params: params,
             req: req,
-            _marker: PhantomData,
         }
     }
-}
 
-impl<'a, TRequest, TBody> RequestBuilder<'a, TRequest, TBody> {
     /**
     Override the parameters for this request.
     
@@ -128,8 +152,8 @@ impl<'a, TRequest, TBody> RequestBuilder<'a, TRequest, TBody> {
     }
 }
 
-impl<'a, TRequest, TBody> RequestBuilder<'a, TRequest, TBody>
-    where TRequest: Into<HttpRequest<'static, TBody>>,
+impl<'a, TRequest, TBody> RequestBuilder<'a, RawRequestBuilder<TRequest, TBody>>
+    where TRequest: Into<HttpRequest<'static, TBody>>, 
           TBody: IntoBody
 {
     fn send_raw(self) -> Result<ResponseBuilder> {
@@ -151,8 +175,8 @@ Call [`Client.request`][Client.request] to get a `RequestBuilder` for a raw requ
 [Client.request]: ../struct.Client.html#method.request
 [endpoints-mod]: endpoints/index.html
 */
-impl<'a, TRequest, TBody> RequestBuilder<'a, TRequest, TBody>
-    where TRequest: Into<HttpRequest<'static, TBody>>,
+impl<'a, TRequest, TBody> RequestBuilder<'a, RawRequestBuilder<TRequest, TBody>>
+    where TRequest: Into<HttpRequest<'static, TBody>>, 
           TBody: IntoBody
 {
     /**

--- a/elastic/src/client/requests/put_mapping.rs
+++ b/elastic/src/client/requests/put_mapping.rs
@@ -3,8 +3,8 @@ use serde_json;
 use serde::Serialize;
 
 use error::*;
-use client::{into_response, Client};
-use client::requests::{Index, Type, IndicesPutMappingRequest, RequestBuilder};
+use client::Client;
+use client::requests::{Index, Type, IndicesPutMappingRequest, RequestBuilder, RawRequestBuilder};
 use client::responses::CommandResponse;
 use types::document::{FieldType, DocumentType, IndexDocumentMapping};
 
@@ -49,10 +49,9 @@ impl Client {
     [types-mod]: ../types/index.html
     [documents-mod]: ../types/document/index.html
     */
-    pub fn put_mapping<'a, TDocument>
-        (&'a self,
-         index: Index<'static>)
-         -> RequestBuilder<'a, PutMappingRequestBuilder<TDocument>, TDocument>
+    pub fn put_mapping<'a, TDocument>(&'a self,
+                                      index: Index<'static>)
+                                      -> RequestBuilder<'a, PutMappingRequestBuilder<TDocument>>
         where TDocument: Serialize + DocumentType
     {
         let ty = TDocument::name().into();
@@ -87,7 +86,7 @@ Call [`Client.put_mapping`][Client.put_mapping] to get a `RequestBuilder` for a 
 [Client.put_mapping]: ../struct.Client.html#method.put_mapping
 [docs-mapping]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
 */
-impl<'a, TDocument> RequestBuilder<'a, PutMappingRequestBuilder<TDocument>, TDocument>
+impl<'a, TDocument> RequestBuilder<'a, PutMappingRequestBuilder<TDocument>>
     where TDocument: DocumentType
 {
     /** Set the type for the put mapping request. */
@@ -102,9 +101,9 @@ impl<'a, TDocument> RequestBuilder<'a, PutMappingRequestBuilder<TDocument>, TDoc
     pub fn send(self) -> Result<CommandResponse> {
         let req = self.req.into_request()?;
 
-        RequestBuilder::new(self.client, self.params, req)
-            .send_raw()
-            .and_then(into_response)
+        RequestBuilder::new(self.client, self.params, RawRequestBuilder::new(req))
+            .send_raw()?
+            .into_response()
     }
 }
 

--- a/elastic/src/client/responses/mod.rs
+++ b/elastic/src/client/responses/mod.rs
@@ -20,8 +20,10 @@ use error::*;
 use client::IntoResponseBuilder;
 use self::parse::IsOk;
 
-pub use elastic_reqwest::res::{SearchResponseOf, GetResponseOf, AggregationIterator, Aggregations, Hit, Hits, Shards, CommandResponse, IndexResponse, PingResponse, BulkResponse,
-                               BulkErrorsResponse, BulkItem, BulkItems, BulkItemError, BulkAction};
+pub use elastic_reqwest::res::{SearchResponseOf, GetResponseOf, AggregationIterator, Aggregations,
+                               Hit, Hits, Shards, CommandResponse, IndexResponse, PingResponse,
+                               BulkResponse, BulkErrorsResponse, BulkItem, BulkItems,
+                               BulkItemError, BulkAction};
 /**
 A builder for a response.
 
@@ -119,9 +121,7 @@ impl ResponseBuilder {
     pub fn into_response<T>(self) -> Result<T>
         where T: IsOk + DeserializeOwned
     {
-        parse()
-            .from_response(self.0)
-            .map_err(Into::into)
+        parse().from_response(self.0).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
- Removes the additional `TBody` generic from `RequestBuilder`, so it only takes a type for the inner request.
- Use `?` instead of `and_then` in a few places

I'm trying to make the request and response types consistent so they could potentially be used as inputs to some `tokio_service::Service` in an async API.