### PR TITLE
Update to stable string-cache

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_derive"
-version = "0.12.3"
+version = "0.13.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Compile-time code generation for Elasticsearch type implementations."

--- a/elastic/Cargo.toml
+++ b/elastic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic"
-version = "0.12.3"
+version = "0.13.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 keywords = ["elasticsearch", "search"]
@@ -27,4 +27,4 @@ elastic_types = "~0.17.1"
 [dev-dependencies]
 json_str = "^0.*"
 serde_derive = "~1"
-elastic_derive = "~0.12.0"
+elastic_derive = { version = "~0.13.0", path = "../derive" }

--- a/elastic/examples/async_sample/Cargo.toml
+++ b/elastic/examples/async_sample/Cargo.toml
@@ -16,4 +16,4 @@ hyper = { git = "https://github.com/hyperium/hyper.git" }
 
 quick-error = "*"
 
-string_cache = { version = "*", git = "https://github.com/KodrAus/string-cache.git", branch = "chore/serde-1.0" }
+string_cache = "*"

--- a/elastic/examples/async_sample/src/body/response.rs
+++ b/elastic/examples/async_sample/src/body/response.rs
@@ -2,7 +2,6 @@ use std::cmp;
 use std::collections::VecDeque;
 use std::io::{Read, Error as IoError};
 
-use futures::{Sink, Poll, Async};
 use hyper::Chunk as HyperChunk;
 
 /// A readable wrapper around a `Chunk`.

--- a/elastic/src/client/responses/mod.rs
+++ b/elastic/src/client/responses/mod.rs
@@ -49,16 +49,6 @@ impl ResponseBuilder {
     
     Convert the builder into a raw HTTP response that implements `Read`.
     */
-    #[deprecated(note = "use `into_raw`")]
-    pub fn raw(self) -> HttpResponse {
-        self.into_raw()
-    }
-
-    /**
-    Get the response body from JSON.
-    
-    Convert the builder into a raw HTTP response that implements `Read`.
-    */
     pub fn into_raw(self) -> HttpResponse {
         HttpResponse(self.0)
     }


### PR DESCRIPTION
- Updates to the stable `string-cache` with `serde 1.0` support
- Removes the deprecated `ResponseBuilder::raw` method
- Update versions to `0.13.0` on `master`