### PR TITLE
Update to elastic_types 0.18.0

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,6 +11,6 @@ name = "elastic_derive"
 proc-macro = true
 
 [dependencies]
-elastic_types_derive_internals = "~0.17.1"
+elastic_types_derive_internals = "~0.18.0"
 syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
 quote = "~0.3.0"

--- a/elastic/Cargo.toml
+++ b/elastic/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "~1"
 reqwest = "~0.6.0"
 
 elastic_reqwest = "~0.8.0"
-elastic_types = "~0.17.1"
+elastic_types = "~0.18.0"
 
 [dev-dependencies]
 json_str = "^0.*"


### PR DESCRIPTION
Fixes an issue with the yanked `0.3.1` version of `chrono`