### PR TITLE
Extract common bench code

### DIFF
--- a/benches/rust/Cargo.toml
+++ b/benches/rust/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    "prepare",
+    "measure",
 	"elastic",
     "elastic_raw",
     "elastic_bulk",

--- a/benches/rust/README.md
+++ b/benches/rust/README.md
@@ -1,0 +1,6 @@
+There are a few crates in the Rust benchmarks:
+
+- `prepare` will index some data in the bench index
+- `measure` is some common functionality for measuring test runs and printing the output
+- `elastic*` are benchmarks for the `elastic` crate
+- `rs-es*` are benchmarks for the `rs-es` crate

--- a/benches/rust/elastic/Cargo.toml
+++ b/benches/rust/elastic/Cargo.toml
@@ -11,5 +11,4 @@ json_str = { version = "*", features = ["nightly"]}
 elastic = { version = "*", path = "../../../elastic", features = ["nightly"] }
 elastic_derive = { version = "*", path = "../../../derive" }
 
-time = "*"
-stopwatch = "*"
+measure = { version = "*", path = "../measure" }

--- a/benches/rust/elastic/src/main.rs
+++ b/benches/rust/elastic/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(test, plugin)]
+#![feature(plugin)]
 #![plugin(json_str)]
 
 #[macro_use]
@@ -6,16 +6,10 @@ extern crate serde_derive;
 #[macro_use]
 extern crate elastic_derive;
 
-extern crate stopwatch;
-extern crate time;
-extern crate test;
-
 extern crate serde;
 extern crate elastic;
 
-use std::env;
-use time::Duration;
-use stopwatch::Stopwatch;
+extern crate measure;
 
 use elastic::http;
 use elastic::prelude::*;
@@ -48,68 +42,20 @@ static BODY: &'static str = json_lit!(
 );
 
 fn main() {
-    let mut args = env::args();
-    let _ = args.next().unwrap();
-    let runs = {
-        if args.len() >= 1 {
-            args.next().unwrap().parse::<i32>().unwrap()
-        } else {
-            200
-        }
-    };
+    let runs = measure::parse_runs_from_env();
 
     let client = ClientBuilder::new()
         .params(|p| p.header(http::header::Connection::keep_alive()))
         .build()
         .unwrap();
+    
+    let results = measure::run(runs, || {
+        client.search::<BenchDoc>()
+              .index("bench_index")
+              .body(BODY)
+              .send()
+              .unwrap()
+    });
 
-    let mut results = Vec::<i64>::with_capacity(runs as usize);
-    for _ in 0..runs {
-        let mut sw = Stopwatch::start_new();
-
-        let res = client.search::<BenchDoc>()
-                        .index("bench_index")
-                        .body(BODY)
-                        .send()
-                        .unwrap();
-
-        sw.stop();
-
-        test::black_box(res);
-
-        let elapsed = Duration::from_std(sw.elapsed()).unwrap();
-        results.push(elapsed.num_nanoseconds().unwrap());
-    }
-
-    results.sort();
-
-    let mean: i64 = results.iter().sum();
-    println!("took mean {}ns", mean / (runs as i64));
-
-    let pv = percentiles(&results, runs as f32);
-
-    for (p, n) in pv {
-        println!("Percentile {}%: {}ns", p * 100f32, n);
-    }
-}
-
-fn percentiles(data: &Vec<i64>, runs: f32) -> Vec<(f32, i64)> {
-    vec![
-        0.50,
-        0.66,
-        0.75,
-        0.80,
-        0.90,
-        0.95,
-        0.98,
-        0.99,
-        1.00
-    ]
-        .iter()
-        .map(|p| {
-            let p: f32 = *p;
-            let i: usize = (p * runs) as usize;
-            (p, data.get(i - 1).unwrap().to_owned())
-        })
-        .collect()
+    println!("{}", results);
 }

--- a/benches/rust/elastic_bulk/Cargo.toml
+++ b/benches/rust/elastic_bulk/Cargo.toml
@@ -10,5 +10,6 @@ profile_memory = []
 elastic = { version = "*", path = "../../../elastic", features = ["nightly"] }
 string_cache = { version = "*", optional = true }
 inlinable_string = { version = "*", features = ["serde"], optional = true }
+lazy_static = { version = "*" }
 
-lazy_static = { version = "*", optional = true }
+measure = { version = "*", path = "../measure" }

--- a/benches/rust/elastic_bulk/src/main.rs
+++ b/benches/rust/elastic_bulk/src/main.rs
@@ -12,24 +12,19 @@
 //! This will avoid allocating multiple copies of the request if the same body
 //! is used multiple times.
 
-#![feature(test)]
-
 #![cfg_attr(feature="profile_memory", feature(alloc_system))]
 #[cfg(feature="profile_memory")]
 extern crate alloc_system;
 
-#[cfg(feature="lazy_static")]
-#[cfg_attr(feature = "lazy_static", macro_use)]
+#[macro_use]
 extern crate lazy_static;
-
 #[cfg(feature="string_cache")]
 extern crate string_cache;
-
 #[cfg(feature="inlinable_string")]
 extern crate inlinable_string;
-
-extern crate test;
 extern crate elastic;
+
+extern crate measure;
 
 use elastic::http;
 use elastic::prelude::*;
@@ -61,34 +56,28 @@ macro_rules! bulk_req {
     })
 }
 
-#[cfg(feature="lazy_static")]
 lazy_static! {
     static ref REQUEST: String = bulk_req!();
 }
 
-#[cfg(not(feature="lazy_static"))]
-fn get_req() -> String {
-    bulk_req!()
-}
-
-#[cfg(feature="lazy_static")]
 fn get_req() -> &'static str {
     &REQUEST
 }
 
 fn main() {
-    // Get a new default client.
+    let runs = measure::parse_runs_from_env();
+
     let client = ClientBuilder::new()
         .params(|p| p.header(http::header::Connection::keep_alive()))
         .build()
         .unwrap();
+    
+    let results = measure::run(runs, || {
+        client.request(BulkRequest::new(get_req()))
+              .send()
+              .and_then(into_response::<BulkResponseType>)
+              .unwrap()
+    });
 
-    // Send the bulk request.
-    let res = client
-        .request(BulkRequest::new(get_req()))
-        .send()
-        .and_then(into_response::<BulkResponseType>)
-        .unwrap();
-
-    test::black_box(res);
+    println!("{}", results);
 }

--- a/benches/rust/elastic_raw/src/main.rs
+++ b/benches/rust/elastic_raw/src/main.rs
@@ -1,16 +1,11 @@
-#![feature(test, plugin)]
+#![feature(plugin)]
 #![plugin(json_str)]
-
-extern crate stopwatch;
-extern crate time;
-extern crate test;
 
 extern crate elastic;
 
-use std::env;
+extern crate measure;
+
 use std::io::Read;
-use time::Duration;
-use stopwatch::Stopwatch;
 
 use elastic::http;
 use elastic::prelude::*;
@@ -27,68 +22,22 @@ static BODY: &'static str = json_lit!(
 );
 
 fn main() {
-    let mut args = env::args();
-    let _ = args.next().unwrap();
-    let runs = {
-        if args.len() >= 1 {
-            args.next().unwrap().parse::<i32>().unwrap()
-        } else {
-            200
-        }
-    };
+    let runs = measure::parse_runs_from_env();
 
     let client = ClientBuilder::new()
         .params(|p| p.header(http::header::Connection::keep_alive()))
         .build()
         .unwrap();
-
-    let mut results = Vec::<i64>::with_capacity(runs as usize);
-    for _ in 0..runs {
-        let mut sw = Stopwatch::start_new();
-
+    
+    let results = measure::run(runs, || {
         let req = SearchRequest::for_index_ty("bench_index", "bench_doc", BODY);
         let mut res = client.request(req).send().unwrap().into_raw();
 
         let mut buf = Vec::new();
         res.read_to_end(&mut buf).unwrap();
 
-        sw.stop();
+        buf
+    });
 
-        test::black_box(buf);
-
-        let elapsed = Duration::from_std(sw.elapsed()).unwrap();
-        results.push(elapsed.num_nanoseconds().unwrap());
-    }
-
-    results.sort();
-
-    let mean: i64 = results.iter().sum();
-    println!("took mean {}ns", mean / (runs as i64));
-
-    let pv = percentiles(&results, runs as f32);
-
-    for (p, n) in pv {
-        println!("Percentile {}%: {}ns", p * 100f32, n);
-    }
-}
-
-fn percentiles(data: &Vec<i64>, runs: f32) -> Vec<(f32, i64)> {
-    vec![
-        0.50,
-        0.66,
-        0.75,
-        0.80,
-        0.90,
-        0.95,
-        0.98,
-        0.99,
-        1.00
-    ]
-        .iter()
-        .map(|p| {
-            let p: f32 = *p;
-            let i: usize = (p * runs) as usize;
-            (p, data.get(i - 1).unwrap().to_owned())
-        })
-        .collect()
+    println!("{}", results);
 }

--- a/benches/rust/measure/.gitignore
+++ b/benches/rust/measure/.gitignore
@@ -1,0 +1,4 @@
+*.bk
+perf.*
+target/
+obj/

--- a/benches/rust/measure/Cargo.toml
+++ b/benches/rust/measure/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "measure"
+version = "0.1.0"
+authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+
+[dependencies]
+time = "*"
+stopwatch = "*"

--- a/benches/rust/measure/src/lib.rs
+++ b/benches/rust/measure/src/lib.rs
@@ -1,0 +1,92 @@
+#![feature(test)]
+
+extern crate stopwatch;
+extern crate time;
+extern crate test;
+
+use std::env;
+use std::fmt;
+use time::Duration;
+use stopwatch::Stopwatch;
+
+pub struct Measure {
+    runs: usize,
+    mean: i64,
+    percentiles: Vec<(f32, i64)>
+}
+
+impl fmt::Display for Measure {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "took mean {}ns", self.mean / (self.runs as i64))?;
+
+        for &(p, n) in &self.percentiles {
+            writeln!(f, "Percentile {}%: {}ns", p * 100f32, n)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn parse_runs_from_env() -> usize {
+    let default_runs = 200;
+
+    let mut args = env::args();
+
+    // Get the command name
+    let _ = args.next().unwrap();
+    
+    // Get the first argument as a usize
+    if args.len() >= 1 {
+        args.next().unwrap().parse::<usize>().unwrap_or(default_runs)
+    } else {
+        default_runs
+    }
+}
+
+pub fn run<F, FOut>(runs: usize, mut f: F) -> Measure
+    where F: FnMut() -> FOut
+{
+    let mut results = Vec::<i64>::with_capacity(runs as usize);
+    for _ in 0..runs {
+        let mut sw = Stopwatch::start_new();
+        let res = f();
+        sw.stop();
+
+        test::black_box(res);
+
+        let elapsed = Duration::from_std(sw.elapsed()).unwrap();
+        results.push(elapsed.num_nanoseconds().unwrap());
+    }
+
+    results.sort();
+
+    let mean: i64 = results.iter().sum();
+    let pv = percentiles(&results, runs as f32);
+
+    Measure {
+        runs: runs,
+        mean: mean,
+        percentiles: pv
+    }
+}
+
+fn percentiles(data: &Vec<i64>, runs: f32) -> Vec<(f32, i64)> {
+    vec![
+        0.50,
+        0.66,
+        0.75,
+        0.80,
+        0.90,
+        0.95,
+        0.98,
+        0.99,
+        1.00
+    ]
+        .iter()
+        .map(|p| {
+            let p: f32 = *p;
+            let i: usize = (p * runs) as usize;
+            (p, data.get(i - 1).unwrap().to_owned())
+        })
+        .collect()
+}

--- a/benches/rust/prepare/.gitignore
+++ b/benches/rust/prepare/.gitignore
@@ -1,0 +1,4 @@
+*.bk
+perf.*
+target/
+obj/

--- a/benches/rust/prepare/Cargo.toml
+++ b/benches/rust/prepare/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
-name = "elastic_bench_raw"
+name = "prepare"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
 [dependencies]
-json_str = { version = "*", features = ["nightly"]}
-
 elastic = { version = "*", path = "../../../elastic", features = ["nightly"] }
-
-measure = { version = "*", path = "../measure" }
+elastic_derive = { version = "*", path = "../../../derive" }
+serde = "*"
+serde_derive = "*"

--- a/benches/rust/prepare/src/main.rs
+++ b/benches/rust/prepare/src/main.rs
@@ -1,0 +1,47 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+
+#[macro_use]
+extern crate elastic_derive;
+extern crate elastic;
+
+use elastic::prelude::*;
+
+#[derive(Debug, Serialize, ElasticType)]
+#[elastic(mapping = "BenchDocMapping")]
+struct BenchDoc {
+    pub id: i32,
+    pub title: String,
+    pub timestamp: Date<EpochMillis>,
+}
+
+#[derive(Default)]
+struct BenchDocMapping;
+impl DocumentMapping for BenchDocMapping {
+    fn name() -> &'static str {
+        "bench_doc"
+    }
+}
+
+fn index() -> Index<'static> {
+    "bench_index".into()
+}
+
+fn main() {
+    let client = ClientBuilder::new().build().unwrap();
+
+    client.create_index(index()).send().unwrap();
+
+    client.put_mapping::<BenchDoc>(index()).send().unwrap();
+
+    for i in 0..10 {
+        let doc = BenchDoc {
+            id: i,
+            title: "Document".into(),
+            timestamp: Date::now(),
+        };
+
+        client.index_document(index(), id(i), &doc).send().unwrap();
+    }
+}

--- a/benches/rust/rs-es/Cargo.toml
+++ b/benches/rust/rs-es/Cargo.toml
@@ -12,5 +12,4 @@ serde_derive = "~1"
 
 rs-es = { version = "*", default-features = false }
 
-stopwatch = "*"
-time = "*"
+measure = { version = "*", path = "../measure" }

--- a/benches/rust/rs-es/src/main.rs
+++ b/benches/rust/rs-es/src/main.rs
@@ -1,18 +1,11 @@
-#![feature(test)]
-
 #[macro_use]
 extern crate serde_derive;
-
-extern crate test;
-extern crate time;
-extern crate stopwatch;
 
 extern crate serde;
 extern crate rs_es;
 
-use std::env;
-use time::Duration;
-use stopwatch::Stopwatch;
+extern crate measure;
+
 use rs_es::Client;
 use rs_es::query::Query;
 use rs_es::operations::search::SearchResult;
@@ -25,24 +18,12 @@ struct BenchDoc {
 }
 
 fn main() {
-    let mut args = env::args();
-    let _ = args.next().unwrap();
-    let runs = {
-        if args.len() >= 1 {
-            args.next().unwrap().parse::<i32>().unwrap()
-        } else {
-            200
-        }
-    };
+    let runs = measure::parse_runs_from_env();
 
     let mut client = Client::new("http://localhost:9200").unwrap();
-
     let qry = Query::build_query_string("*").build();
-
-    let mut results = Vec::<i64>::with_capacity(runs as usize);
-    for _ in 0..runs {
-        let mut sw = Stopwatch::start_new();
-
+    
+    let results = measure::run(runs, || {
         let res: SearchResult<BenchDoc> = client.search_query()
             .with_indexes(&["bench_index"])
             .with_types(&["bench_doc"])
@@ -51,33 +32,8 @@ fn main() {
             .send()
             .unwrap();
 
-        sw.stop();
+        res
+    });
 
-        test::black_box(res);
-
-        let elapsed = Duration::from_std(sw.elapsed()).unwrap();
-        results.push(elapsed.num_nanoseconds().unwrap());
-    }
-
-    results.sort();
-
-    let mean: i64 = results.iter().sum();
-    println!("took mean {}ns", mean / (runs as i64));
-
-    let pv = percentiles(&results, runs as f32);
-
-    for (p, n) in pv {
-        println!("Percentile {}%: {}ns", p * 100f32, n);
-    }
-}
-
-fn percentiles(data: &Vec<i64>, runs: f32) -> Vec<(f32, i64)> {
-    vec![0.50, 0.66, 0.75, 0.80, 0.90, 0.95, 0.98, 0.99, 1.00]
-        .iter()
-        .map(|p| {
-            let p: f32 = *p;
-            let i: usize = (p * runs) as usize;
-            (p, data.get(i - 1).unwrap().to_owned())
-        })
-        .collect()
+    println!("{}", results);
 }


### PR DESCRIPTION
Makes it easier to add new benches and see what they're doing by extracting the bench running and reporting into a common crate. At some point we should look into proper benchmarking for the client, using a proper benchmarking framework instead of this home-grown one.