### PR TITLE
Add basic request logging

### DIFF
--- a/elastic/Cargo.toml
+++ b/elastic/Cargo.toml
@@ -16,6 +16,8 @@ appveyor = { repository = "elastic-rs/elastic" }
 nightly = ["elastic_reqwest/nightly"]
 
 [dependencies]
+log = "*"
+uuid = { version = "*", features = [ "v4" ] }
 error-chain = "~0.9.0"
 serde = "~1"
 serde_json = "~1"
@@ -25,6 +27,7 @@ elastic_reqwest = "~0.8.0"
 elastic_types = "~0.18.0"
 
 [dev-dependencies]
+env_logger = "*"
 json_str = "^0.*"
 serde_derive = "~1"
 elastic_derive = "~0.13.1"

--- a/elastic/Cargo.toml
+++ b/elastic/Cargo.toml
@@ -16,8 +16,8 @@ appveyor = { repository = "elastic-rs/elastic" }
 nightly = ["elastic_reqwest/nightly"]
 
 [dependencies]
-log = "*"
-uuid = { version = "*", features = [ "v4" ] }
+log = "~0.3.8"
+uuid = { version = "~0.5.1", features = [ "v4" ] }
 error-chain = "~0.9.0"
 serde = "~1"
 serde_json = "~1"
@@ -27,7 +27,7 @@ elastic_reqwest = "~0.8.0"
 elastic_types = "~0.18.0"
 
 [dev-dependencies]
-env_logger = "*"
+env_logger = "~0.4.3"
 json_str = "^0.*"
 serde_derive = "~1"
 elastic_derive = "~0.13.1"

--- a/elastic/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
+++ b/elastic/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
@@ -1,6 +1,6 @@
 use ops::Client;
 use std::io::Error as IoError;
-use serde_json::{Value, Error as JsonError};
+use serde_json::Error as JsonError;
 use elastic::client::requests::IndicesExistsRequest;
 use elastic::client::responses::CommandResponse;
 use elastic::error::Error as ResponseError;

--- a/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/elastic/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -2,7 +2,6 @@ use std::io::{Result as IoResult, Error as IoError};
 use std::fs::File;
 use std::path::Path;
 use ops::Client;
-use elastic::client::into_response;
 use elastic::client::requests::{IntoBody, BulkRequest};
 use elastic::client::responses::{BulkErrorsResponse, BulkItemError};
 use elastic::error::Error as ResponseError;

--- a/elastic/examples/basic.rs
+++ b/elastic/examples/basic.rs
@@ -5,6 +5,7 @@
 //! This sample executes a search request and iterates through the returned hits
 //! as anonymous json objects.
 
+extern crate env_logger;
 #[macro_use]
 extern crate serde_json;
 extern crate elastic;
@@ -13,6 +14,8 @@ use serde_json::Value;
 use elastic::prelude::*;
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
     let client = ClientBuilder::new().build().unwrap();

--- a/elastic/examples/bulk.rs
+++ b/elastic/examples/bulk.rs
@@ -7,11 +7,14 @@
 //! performance out of them.
 //! See the docs for `BulkResponse` for more details.
 
+extern crate env_logger;
 extern crate elastic;
 
 use elastic::prelude::*;
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A HTTP client and request parameters
     let client = ClientBuilder::new().build().unwrap();
 

--- a/elastic/examples/custom_response.rs
+++ b/elastic/examples/custom_response.rs
@@ -5,6 +5,7 @@
 //! This sample demonstrates creating a custom `SearchResponse` type that can be used with
 //! the `filter_path` query parameter to only return the matched hits.
 
+extern crate env_logger;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -45,6 +46,8 @@ impl IsOk for SearchResponse {
 }
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
     let client = ClientBuilder::new().build().unwrap();

--- a/elastic/examples/get.rs
+++ b/elastic/examples/get.rs
@@ -7,6 +7,7 @@
 //! exists, and the document is indexed.
 //! Also see the `typed` sample for a more complete implementation.
 
+extern crate env_logger;
 extern crate serde_json;
 extern crate elastic;
 
@@ -15,6 +16,8 @@ use elastic::error::*;
 use elastic::prelude::*;
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
     let client = ClientBuilder::new().build().unwrap();

--- a/elastic/examples/index.rs
+++ b/elastic/examples/index.rs
@@ -5,6 +5,7 @@
 //! This sample demonstrates how to create an index, add type mapping, and index a document.
 //! Also see the `typed` sample for a more complete implementation.
 
+extern crate env_logger;
 #[macro_use]
 extern crate elastic_derive;
 #[macro_use]
@@ -23,6 +24,8 @@ struct MyType {
 }
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A HTTP client and request parameters
     let client = ClientBuilder::new().build().unwrap();
 

--- a/elastic/examples/ping.rs
+++ b/elastic/examples/ping.rs
@@ -2,11 +2,14 @@
 //!
 //! NOTE: This sample expects you have a node running on `localhost:9200`.
 
+extern crate env_logger;
 extern crate elastic;
 
 use elastic::prelude::*;
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A HTTP client and request parameters
     let client = ClientBuilder::new().build().unwrap();
 

--- a/elastic/examples/raw.rs
+++ b/elastic/examples/raw.rs
@@ -5,12 +5,15 @@
 //! This sample demonstrates a raw search request where the body is read into a `String` rather
 //! than being deserialised.
 
+extern crate env_logger;
 extern crate elastic;
 
 use std::io::Read;
 use elastic::prelude::*;
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
     let params = RequestParams::default().url_param("pretty", true);

--- a/elastic/examples/typed.rs
+++ b/elastic/examples/typed.rs
@@ -10,6 +10,7 @@
 //! - Index a document
 //! - Search the index and iterate over hits
 
+extern crate env_logger;
 #[macro_use]
 extern crate json_str;
 #[macro_use]
@@ -31,6 +32,8 @@ struct MyType {
 }
 
 fn main() {
+    env_logger::init().unwrap();
+
     // A HTTP client and request parameters
     let client = ClientBuilder::new().build().unwrap();
 

--- a/elastic/examples/typed.rs
+++ b/elastic/examples/typed.rs
@@ -81,7 +81,7 @@ fn ensure_indexed(client: &Client, doc: MyType) {
             put_doc(client, doc);
         }
         // Something went wrong: panic
-        Err(e) => panic!(e),
+        Err(e) => panic!("{:?}", e),
     }
 }
 

--- a/elastic/src/client/requests/mod.rs
+++ b/elastic/src/client/requests/mod.rs
@@ -160,14 +160,22 @@ impl<'a, TRequest, TBody> RequestBuilder<'a, RawRequestBuilder<TRequest, TBody>>
     fn send_raw(self) -> Result<ResponseBuilder> {
         let correlation_id = Uuid::new_v4();
         let params = self.params.as_ref().unwrap_or(&self.client.params);
+        let req = self.req.inner.into();
 
-        let req: HttpRequest<_> = self.req.into();
+        info!("Elasticsearch Request: correlation_id: '{}', path: '{}'", correlation_id, req.url.as_ref());
 
-        debug!("Elasticsearch Request: correlation_id: '{}', path: '{}'", correlation_id, req.url.as_ref());
+        let res = match self.client.http.elastic_req(params, req) {
+            Ok(res) => {
+                info!("Elasticsearch Response: correlation_id: '{}', status: '{}'", correlation_id, res.status());
 
-        let res = self.client.http.elastic_req(params, req)?;
+                res
+            },
+            Err(e) => {
+                error!("Elasticsearch Response: correlation_id: '{}', error: '{}'", correlation_id, e);
 
-        debug!("Elasticsearch Response: correlation_id: '{}', status: '{}'", correlation_id, res.status());
+                Err(e)?
+            }
+        };
 
         Ok(IntoResponseBuilder(res).into())
     }

--- a/elastic/src/lib.rs
+++ b/elastic/src/lib.rs
@@ -266,6 +266,9 @@ This crate glues these libraries together with some simple assumptions about how
 #![deny(missing_docs)]
 
 #[macro_use]
+extern crate log;
+extern crate uuid;
+#[macro_use]
 extern crate error_chain;
 extern crate serde;
 extern crate serde_json;


### PR DESCRIPTION
Closes #219 

Adds some really basic logging to requests and hooks up `env_logger` in each example. Set:

```
export RUST_LOG=debug
```

To see logs for Elasticsearch requests.