### PR TITLE
Fix build on nightly

### DIFF
--- a/elastic/src/error.rs
+++ b/elastic/src/error.rs
@@ -35,8 +35,7 @@ match res {
 ```
 */
 
-#![allow(missing_docs)]
-#![allow(unused_doc_comment)]
+#![allow(missing_docs, unknown_lints, unused_doc_comment)]
 
 use serde_json::Error as JsonError;
 use reqwest::Error as ReqwestError;

--- a/elastic/src/error.rs
+++ b/elastic/src/error.rs
@@ -36,6 +36,7 @@ match res {
 */
 
 #![allow(missing_docs)]
+#![allow(unused_doc_comment)]
 
 use serde_json::Error as JsonError;
 use reqwest::Error as ReqwestError;


### PR DESCRIPTION
Fixes an issue with some unused doc comments in the `error_chain` macro that are reported as a warning on the latest `nightly`.