### PR TITLE
Track latest reqwest release

### DIFF
--- a/benches/elastic/Cargo.toml
+++ b/benches/elastic/Cargo.toml
@@ -2,9 +2,10 @@
 name = "elastic_bench"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
-elastic = { version = "*", path = "../../src/elastic", features = ["nightly"] }
+elastic = { version = "*", path = "../../src/elastic" }
 elastic_derive = { version = "*", path = "../../src/elastic_derive" }
 serde = "*"
 serde_derive = "*"

--- a/benches/elastic_bulk/Cargo.toml
+++ b/benches/elastic_bulk/Cargo.toml
@@ -2,6 +2,7 @@
 name = "elastic_bench_bulk"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [features]
 default = ["profile_memory","gzip"]

--- a/benches/elastic_bulk/src/main.rs
+++ b/benches/elastic_bulk/src/main.rs
@@ -69,12 +69,12 @@ fn get_req() -> &'static str {
 
 #[cfg(feature="gzip")]
 fn http_client() -> reqwest::Client {
-    reqwest::Client::new().unwrap()
+    reqwest::Client::new()
 }
 
 #[cfg(not(feature="gzip"))]
 fn http_client() -> reqwest::Client {
-    let mut http = reqwest::Client::new().unwrap();
+    let mut http = reqwest::Client::new();
     http.gzip(false);
 
     http

--- a/benches/elastic_raw/Cargo.toml
+++ b/benches/elastic_raw/Cargo.toml
@@ -2,6 +2,7 @@
 name = "elastic_bench_raw"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
 elastic = { version = "*", path = "../../src/elastic" }

--- a/benches/measure/Cargo.toml
+++ b/benches/measure/Cargo.toml
@@ -2,6 +2,7 @@
 name = "measure"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
 time = "*"

--- a/benches/prepare/Cargo.toml
+++ b/benches/prepare/Cargo.toml
@@ -2,9 +2,10 @@
 name = "prepare"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
-elastic = { version = "*", path = "../../elastic", features = ["nightly"] }
-elastic_derive = { version = "*", path = "../../derive" }
+elastic = { version = "*", path = "../../src/elastic" }
+elastic_derive = { version = "*", path = "../../src/elastic_derive" }
 serde = "*"
 serde_derive = "*"

--- a/benches/rs-es/Cargo.toml
+++ b/benches/rs-es/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rs-es_bench"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [features]
 ssl = ["rs-es/ssl"]

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -1,3 +1,5 @@
+set -ex
+
 cargo test --verbose --all
 cargo bench --verbose --all
 

--- a/ci/stable.sh
+++ b/ci/stable.sh
@@ -1,2 +1,4 @@
+set -ex
+
 cd src/elastic
 cargo test

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -1,3 +1,3 @@
-set -x
+set -ex
 
 ./ci/${CHANNEL}.sh

--- a/examples/account_sample/Cargo.toml
+++ b/examples/account_sample/Cargo.toml
@@ -2,6 +2,7 @@
 name = "account-sample"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
 elastic = { version = "*", path = "../../src/elastic" }

--- a/examples/async_raw_sample/Cargo.toml
+++ b/examples/async_raw_sample/Cargo.toml
@@ -2,6 +2,7 @@
 name = "async-raw-sample"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
 elastic_requests = { version = "*", path = "../../src/requests" }

--- a/src/elastic/src/client/async.rs
+++ b/src/elastic/src/client/async.rs
@@ -3,7 +3,7 @@ use futures::Future;
 use futures_cpupool::CpuPool;
 use tokio_core::reactor::Handle;
 use elastic_reqwest::{AsyncBody, AsyncElasticClient};
-use reqwest::unstable::async::Client as AsyncHttpClient;
+use reqwest::unstable::async::{Client as AsyncHttpClient, ClientBuilder as AsyncHttpClientBuilder};
 
 use error::{self, Error, Result};
 use client::requests::HttpRequest;
@@ -237,7 +237,7 @@ impl AsyncClientBuilder {
     */
     pub fn build(self, handle: &Handle) -> Result<AsyncClient> {
         let http = self.http.map(Ok)
-                            .unwrap_or_else(|| AsyncHttpClient::new(handle))
+                            .unwrap_or_else(|| AsyncHttpClientBuilder::new().build(handle))
                             .map_err(error::build)?;
 
         Ok(AsyncClient {

--- a/src/elastic/src/client/sync.rs
+++ b/src/elastic/src/client/sync.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 use elastic_reqwest::{SyncBody, SyncElasticClient};
-use reqwest::Client as SyncHttpClient;
+use reqwest::{Client as SyncHttpClient, ClientBuilder as SyncHttpClientBuilder};
 
 use error::{self, Result};
 use client::requests::HttpRequest;
@@ -189,7 +189,7 @@ impl SyncClientBuilder {
     */
     pub fn build(self) -> Result<SyncClient> {
         let http = self.http.map(Ok)
-                            .unwrap_or_else(SyncHttpClient::new)
+                            .unwrap_or_else(|| SyncHttpClientBuilder::new().build())
                             .map_err(error::build)?;
 
         Ok(SyncClient {

--- a/src/reqwest/benches/mod.rs
+++ b/src/reqwest/benches/mod.rs
@@ -109,7 +109,7 @@ macro_rules! build_request_sync {
             #[bench]
             fn $name(b: &mut test::Bencher) {
                 let params = RequestParams::default();
-                let cli = ClientSync::new().unwrap();
+                let cli = ClientSync::new();
 
                 b.iter(|| {
                     build_req_sync(&cli, &params, PingRequest::new())
@@ -127,7 +127,7 @@ macro_rules! build_request_async {
                 let core = Core::new().unwrap();
 
                 let params = RequestParams::default();
-                let cli = ClientAsync::new(&core.handle()).unwrap();
+                let cli = ClientAsync::new(&core.handle());
 
                 b.iter(|| {
                     build_req_async(&cli, &params, PingRequest::new())

--- a/src/types/tests/derive_compile_test/Cargo.toml
+++ b/src/types/tests/derive_compile_test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "derive_compile_test"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
 elastic_types = { version = "*", path = "../../" }

--- a/tests/run/Cargo.toml
+++ b/tests/run/Cargo.toml
@@ -2,6 +2,7 @@
 name = "run"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+publish = false
 
 [dependencies]
 elastic = { version = "*", path = "../../src/elastic" }


### PR DESCRIPTION
We're tracking the `master` branch of `reqwest`, which now requires using a builder to handle errors instead of panicking.