### PR TITLE
Cleanup futures and preludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,13 @@ let query = "some query string";
 // A search request with a freeform body.
 let res = client.search::<Value>()
                 .index("_all")
-                .body({
-                    json!({
-                        "query": {
-                            "query_string": {
-                                "query": query
-                            }
+                .body(json!({
+                    "query": {
+                        "query_string": {
+                            "query": query
                         }
-                    })
-                })
+                    }
+                }))
                 .send()?;
 
 // Iterate through the hits in the response.
@@ -117,7 +115,7 @@ The `elastic` crate brings a few independent crates together into a cohesive API
 - `reqwest`/`hyper` for HTTP transport
 - `serde` for serialisation
 
-There hasn't been much effort put into abstracting these dependencies at this stage, and `elastic` can't stabilise until these libraries and few others do.
+There hasn't been much effort put into abstracting these dependencies at this stage, and `elastic` can't stabilise until these libraries and a few others do.
 
 ### Methodology
 
@@ -146,8 +144,7 @@ The following is a simple set of guidelines that the codebase should follow. It'
 - Types should have detailed docs with general examples
 - Type methods should have examples and document any panics/error cases
 - Modules should have general guidance for the types they contain
-- `elastic` should link back to the underlying crate when it re-exports a feature
-- Crates should link to `elastic` when it re-exports that feature
+- Make it easy to navigate between related types. `elastic` uses a lot of generic code that can be hard to follow, so we need to work hard to help the user follow what's happening
 
 ## Navigating the repository
 

--- a/benches/elastic_async/Cargo.toml
+++ b/benches/elastic_async/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "elastic_async_bench"
+version = "0.1.0"
+authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+
+[dependencies]
+elastic = { version = "*", path = "../../src/elastic", features = ["nightly"] }
+elastic_derive = { version = "*", path = "../../src/elastic_derive" }
+tokio_core = "*"
+futures = "*"
+serde = "*"
+serde_derive = "*"
+json_str = { version = "*", features = ["nightly"]}
+
+measure = { version = "*", path = "../measure" }

--- a/benches/elastic_async/src/main.rs
+++ b/benches/elastic_async/src/main.rs
@@ -1,0 +1,64 @@
+#![feature(plugin)]
+#![plugin(json_str)]
+
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate elastic_derive;
+extern crate futures;
+extern crate tokio_core;
+
+extern crate serde;
+extern crate elastic;
+
+extern crate measure;
+
+use elastic::http;
+use elastic::prelude::*;
+
+#[derive(Debug, Deserialize, ElasticType)]
+#[elastic(mapping = "BenchDocMapping")]
+struct BenchDoc {
+    pub id: i32,
+    pub title: String,
+    pub timestamp: Date<DefaultDateMapping<EpochMillis>>,
+}
+
+#[derive(Default)]
+struct BenchDocMapping;
+impl DocumentMapping for BenchDocMapping {
+    fn name() -> &'static str {
+        "bench_doc"
+    }
+}
+
+static BODY: &'static str = json_lit!(
+    {
+        query: {
+            query_string: {
+                query: "*"
+            }
+        },
+        size: 10
+    }
+);
+
+fn main() {
+    let runs = measure::parse_runs_from_env();
+
+    let client = AsyncClientBuilder::new()
+        .params(|p| p.header(http::header::Connection::keep_alive()))
+        .build(&core.handle())
+        .unwrap();
+    
+    let results_future = measure::run_future(runs, || {
+        client.search::<BenchDoc>()
+              .index("bench_index")
+              .body(BODY)
+              .send()
+    });
+
+    results = core.run(results_future).unwrap();
+
+    println!("{}", results);
+}

--- a/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
+++ b/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
@@ -3,7 +3,7 @@ use std::io::Error as IoError;
 use serde_json::Error as JsonError;
 use elastic::client::requests::IndicesExistsRequest;
 use elastic::client::responses::CommandResponse;
-use elastic::error::Error as ResponseError;
+use elastic::Error as ResponseError;
 
 use model;
 

--- a/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use ops::Client;
 use elastic::client::requests::{SyncBody, BulkRequest};
 use elastic::client::responses::bulk::{BulkErrorsResponse, ErrorItem};
-use elastic::error::Error as ResponseError;
+use elastic::Error as ResponseError;
 
 use model;
 

--- a/src/elastic/examples/typed_async.rs
+++ b/src/elastic/examples/typed_async.rs
@@ -131,7 +131,7 @@ fn put_doc(client: AsyncClient, doc: MyType) -> Box<Future<Item = (), Error = Er
 }
 
 fn search(client: AsyncClient, query: &'static str) -> Box<Future<Item = SearchResponse<MyType>, Error = Error>> {
-    client
+    let search = client
         .search()
         .index(sample_index())
         .body(json!({
@@ -141,7 +141,9 @@ fn search(client: AsyncClient, query: &'static str) -> Box<Future<Item = SearchR
                     }
                 }
           }))
-        .send()
+        .send();
+    
+    Box::new(search)
 }
 
 fn main() {

--- a/src/elastic/src/client/mod.rs
+++ b/src/elastic/src/client/mod.rs
@@ -57,7 +57,7 @@ Requests can be sent with an instance of a client using a builder API:
 # extern crate elastic;
 # use serde_json::Value;
 # use elastic::prelude::*;
-# use elastic::error::Error;
+# use elastic::Error;
 # fn main() { run().unwrap() }
 # fn run() -> Result<(), Box<::std::error::Error>> {
 # let client = SyncClientBuilder::new().build()?;
@@ -289,7 +289,7 @@ Call [`SyncResponseBuilder.into_response`][SyncResponseBuilder.into_response] on
 # extern crate elastic;
 # use serde_json::Value;
 # use elastic::prelude::*;
-# use elastic::error::Error;
+# use elastic::Error;
 # fn main() { run().unwrap() }
 # fn run() -> Result<(), Box<::std::error::Error>> {
 # #[derive(Serialize, Deserialize, ElasticType)]
@@ -569,6 +569,14 @@ core.run(response_future)?;
 pub struct Client<TSender> {
     sender: TSender,
     params: RequestParams,
+}
+
+pub mod prelude {
+    /*! A glob import for convenience. */
+
+    pub use super::{SyncClientBuilder, AsyncClientBuilder, SyncClient, AsyncClient, RequestParams};
+    pub use super::requests::prelude::*;
+    pub use super::responses::prelude::*;
 }
 
 #[cfg(test)]

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -16,23 +16,23 @@ pub use elastic_reqwest::req::endpoints;
 pub use self::params::*;
 pub use self::endpoints::*;
 
-mod raw;
+pub mod raw;
 pub use self::raw::RawRequestBuilder;
 
 // Search requests
-mod search;
+pub mod search;
 pub use self::search::SearchRequestBuilder;
 
 // Document requests
-mod document_get;
-mod document_index;
-mod document_put_mapping;
+pub mod document_get;
+pub mod document_index;
+pub mod document_put_mapping;
 pub use self::document_get::GetRequestBuilder;
 pub use self::document_index::IndexRequestBuilder;
 pub use self::document_put_mapping::PutMappingRequestBuilder;
 
 // Index requests
-mod index_create;
+pub mod index_create;
 pub use self::index_create::IndexCreateRequestBuilder;
 
 /**
@@ -168,8 +168,18 @@ impl<TRequest> RequestBuilder<AsyncSender, TRequest> {
     }
 }
 
+pub mod prelude {
+    /*! A glob import for convenience. */
+
+    pub use super::params::*;
+    pub use super::endpoints::*;
+
+    pub use super::{empty_body, DefaultBody, RawRequestBuilder, SearchRequestBuilder, GetRequestBuilder, IndexRequestBuilder, PutMappingRequestBuilder, IndexCreateRequestBuilder};
+}
+
 #[cfg(test)]
 mod tests {
+    use super::RequestBuilder;
     use prelude::*;
 
     #[test]

--- a/src/elastic/src/client/requests/raw.rs
+++ b/src/elastic/src/client/requests/raw.rs
@@ -1,3 +1,7 @@
+/*!
+Builders for raw requests.
+*/
+
 use std::marker::PhantomData;
 
 use client::{Client, Sender};
@@ -9,7 +13,7 @@ A raw request builder that can be configured before sending.
 Call [`Client.request`][Client.request] to get an `IndexRequest`. 
 The `send` method will either send the request synchronously or asynchronously, depending on the `Client` it was created from.
 
-[Client.request]: ../struct.Client.html#raw-request
+[Client.request]: ../../struct.Client.html#raw-request
 */
 pub type RawRequestBuilder<TSender, TRequest, TBody> = RequestBuilder<TSender, RawRequestInner<TRequest, TBody>>;
 
@@ -20,7 +24,7 @@ pub struct RawRequestInner<TRequest, TBody> {
 }
 
 impl<TRequest, TBody> RawRequestInner<TRequest, TBody> {
-    pub fn new(req: TRequest) -> Self {
+    pub(crate) fn new(req: TRequest) -> Self {
         RawRequestInner {
             req: req,
             _marker: PhantomData,
@@ -65,7 +69,7 @@ impl<TSender> Client<TSender>
     ```
 
     [HttpRequest]: requests/struct.HttpRequest.html
-    [RawRequestBuilder]: requests/type.RawRequestBuilder.html
+    [RawRequestBuilder]: requests/raw/type.RawRequestBuilder.html
     [endpoints-mod]: requests/endpoints/index.html
     */
     pub fn request<TRequest, TBody>(&self, req: TRequest) -> RawRequestBuilder<TSender, TRequest, TBody>
@@ -144,10 +148,10 @@ impl<TSender, TRequest, TBody> RawRequestBuilder<TSender, TRequest, TBody>
     # }
     ```
 
-    [SyncClient]: ../type.SyncClient.html
-    [SyncResponseBuilder]: ../responses/struct.SyncResponseBuilder.html
-    [AsyncClient]: ../type.AsyncClient.html
-    [AsyncResponseBuilder]: ../responses/struct.AsyncResponseBuilder.html
+    [SyncClient]: ../../type.SyncClient.html
+    [SyncResponseBuilder]: ../../responses/struct.SyncResponseBuilder.html
+    [AsyncClient]: ../../type.AsyncClient.html
+    [AsyncResponseBuilder]: ../../responses/struct.AsyncResponseBuilder.html
     */
     pub fn send(self) -> TSender::Response {
         let client = self.client;

--- a/src/elastic/src/client/responses/mod.rs
+++ b/src/elastic/src/client/responses/mod.rs
@@ -21,3 +21,13 @@ pub use elastic_reqwest::res::{SearchResponse, GetResponse, Shards, CommandRespo
 
 pub use elastic_reqwest::res::search;
 pub use elastic_reqwest::res::bulk;
+
+pub mod prelude {
+    /*! A glob import for convenience. */
+
+    pub use super::{SearchResponse, GetResponse, Shards, CommandResponse, IndexResponse, PingResponse,
+                               BulkResponse, BulkErrorsResponse};
+
+    pub use super::async::AsyncResponseBuilder;
+    pub use super::sync::SyncResponseBuilder;
+}

--- a/src/elastic/src/client/responses/parse.rs
+++ b/src/elastic/src/client/responses/parse.rs
@@ -41,7 +41,7 @@ The `MyResponse` type can then be used for deserialising a concrete response:
 # #[macro_use] extern crate serde_derive;
 # extern crate elastic;
 # use elastic::prelude::*;
-# use elastic::error::Error;
+# use elastic::Error;
 # use elastic::client::responses::parse::*;
 # #[derive(Deserialize)]
 # struct MyResponse {

--- a/src/elastic/src/error.rs
+++ b/src/elastic/src/error.rs
@@ -13,7 +13,7 @@ The below example sends a request and then checks the response for an `Error::Ap
 # extern crate serde_json;
 # use serde_json::Value;
 # use elastic::prelude::*;
-# use elastic::error::Error;
+# use elastic::Error;
 # fn main() { run().unwrap() }
 # fn run() -> Result<(), Box<::std::error::Error>> {
 # let client = SyncClientBuilder::new().build()?;

--- a/src/elastic/src/lib.rs
+++ b/src/elastic/src/lib.rs
@@ -237,10 +237,10 @@ for hit in response.hits() {
 
 This crate is mostly a meta-package composed of a number of smaller pieces including:
 
-- [`elastic_reqwest`][elastic-reqwest] HTTP transport
-- [`elastic_requests`][elastic-requests] API request builders
-- [`elastic_responses`][elastic-responses] API response parsers
-- [`elastic_types`][elastic-types] tools for document and mapping APIs
+- `elastic_reqwest` HTTP transport
+- `elastic_requests` API request builders
+- `elastic_responses` API response parsers
+- `elastic_types` tools for document and mapping APIs
 
 This crate glues these libraries together with some simple assumptions about how they're going to be used.
 
@@ -254,11 +254,6 @@ This crate glues these libraries together with some simple assumptions about how
 [tokio]: https://tokio.rs
 [crates-io]: https://crates.io/crates/elastic
 [github]: https://github.com/elastic-rs/elastic
-
-[elastic-reqwest]: https://github.com/elastic-rs/elastic-reqwest
-[elastic-requests]: https://github.com/elastic-rs/elastic-requests
-[elastic-responses]: https://github.com/elastic-rs/elastic-responses
-[elastic-types]: https://github.com/elastic-rs/elastic-types
 
 [docs-root]: https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 [docs-mapping]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
@@ -295,6 +290,7 @@ extern crate elastic_reqwest;
 extern crate elastic_types;
 
 pub mod error;
+pub use error::Error;
 
 pub mod http {
     /*! 
@@ -315,9 +311,7 @@ pub mod types;
 pub mod prelude {
     /*! A glob import for convenience. */
 
-    pub use client::{SyncClientBuilder, AsyncClientBuilder, SyncClient, AsyncClient, RequestParams};
-    pub use client::requests::*;
-    pub use client::responses::*;
+    pub use client::prelude::*;
     pub use types::prelude::*;
 }
 

--- a/src/reqwest/src/lib.rs
+++ b/src/reqwest/src/lib.rs
@@ -226,6 +226,10 @@ extern crate bytes;
 extern crate tokio_core;
 extern crate futures;
 
+mod private {
+    pub trait Sealed {}
+}
+
 pub mod sync;
 pub mod async;
 

--- a/src/reqwest/src/sync.rs
+++ b/src/reqwest/src/sync.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use reqwest::{Client, ClientBuilder, RequestBuilder, Response, Body};
 
+use private;
 use super::req::HttpRequest;
 use super::res::parsing::{Parse, IsOk};
 use super::{Error, RequestParams, build_url, build_method};
@@ -80,7 +81,7 @@ impl From<&'static str> for SyncBody {
 }
 
 /** Represents a client that can send Elasticsearch requests synchronously. */
-pub trait SyncElasticClient {
+pub trait SyncElasticClient: private::Sealed {
     /** 
     Send a request and get a response.
     
@@ -139,6 +140,8 @@ impl SyncElasticClient for Client {
         build_req(&self, params, req).send().map_err(Into::into)
     }
 }
+
+impl private::Sealed for Client {}
 
 /** Represents a response that can be parsed into a concrete Elasticsearch response. */
 pub trait SyncFromResponse<TResponse> {

--- a/tests/run/src/build_client.rs
+++ b/tests/run/src/build_client.rs
@@ -1,6 +1,6 @@
 use tokio_core::reactor::Handle;
 use elastic::prelude::*;
-use elastic::error::Error;
+use elastic::Error;
 
 pub fn call(handle: &Handle, run: &str) -> Result<AsyncClient, Error> {
     match run {

--- a/tests/run/src/run_tests.rs
+++ b/tests/run/src/run_tests.rs
@@ -4,7 +4,7 @@ use term_painter::ToStyle;
 use term_painter::Color::*;
 use futures::{stream, Future, Stream};
 use elastic::prelude::*;
-use elastic::error::Error;
+use elastic::Error;
 
 pub type TestResult = bool;
 pub type Test = Box<Fn(AsyncClient) -> Box<Future<Item = TestResult, Error = ()>>>;

--- a/tests/run/src/search/no_index.rs
+++ b/tests/run/src/search/no_index.rs
@@ -24,10 +24,12 @@ impl IntegrationTest for NoIndex {
 
     // Execute a search request against that index
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
-        client.search()
-              .index("no_index_idx")
-              .ty(Some("no_index_ty"))
-              .send()
+        let res = client.search()
+                        .index("no_index_idx")
+                        .ty(Some("no_index_ty"))
+                        .send();
+        
+        Box::new(res)
     }
 
     // Ensure an `IndexNotFound` error is returned

--- a/tests/run/src/wait_until_ready.rs
+++ b/tests/run/src/wait_until_ready.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio_timer::Timer;
 use futures::{stream, Future, Stream};
 use elastic::prelude::*;
-use elastic::error::Error;
+use elastic::Error;
 
 #[derive(Clone)]
 struct Ping {


### PR DESCRIPTION
Part of #231.

- add explicit preludes so we can control exported types better
- add concrete futures in place of Boxes
- tidy up some links and readme