### PR TITLE
Upload docs on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Windows  | Nightly | [![Build status](https://ci.appveyor.com/api/projects/statu
 
 ## Documentation
 
-Version  | Docs
+Version       | Docs
 ------------- | -------------
-`current`  | [![Documentation](https://img.shields.io/badge/docs-rustdoc-orange.svg)](https://docs.rs/elastic/*/elastic/)
+`current`     | [![Documentation](https://img.shields.io/badge/docs-rustdoc-blue.svg)](https://docs.rs/elastic/*/elastic/)
+`master`      | [![Documentation](https://img.shields.io/badge/docs-rustdoc-orange.svg)](http://elastic-rs.github.io/elastic/elastic/index.html)
 
 ## Example
 

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -2,9 +2,16 @@
 
 set -o errexit -o nounset
 
-BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+cargo test --verbose --all
+cargo bench --verbose --all
 
-echo $BRANCH
+cd benches
+cargo build --all
+
+cd ../tests/run
+cargo run
+
+BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
 if [ "$BRANCH" == "master" ]; then
     echo "uploading crate docs"
@@ -23,12 +30,3 @@ if [ "$BRANCH" == "master" ]; then
     echo "Pushing gh-pages to GitHub"
     git push -q upstream HEAD:refs/heads/gh-pages --force
 fi
-
-cargo test --verbose --all
-cargo bench --verbose --all
-
-cd benches
-cargo build --all
-
-cd ../tests/run
-cargo run

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -2,9 +2,11 @@
 
 set -o errexit -o nounset
 
-echo $TRAVIS_BRANCH
+BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
-if [ "$TRAVIS_BRANCH" = "master" ]; then
+echo $BRANCH
+
+if [ "$BRANCH" == "master" ]; then
     echo "uploading crate docs"
 
     cargo doc --all

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -9,22 +9,19 @@ cargo build --all
 cd ../tests/run
 cargo run
 
-if [ "$TRAVIS_BRANCH" != "master" ]; then
-    echo "ignoring doc upload on non-master branch"
-    exit 0
+if [ "$TRAVIS_BRANCH" = "master" ]; then
+    cd ../../
+    cargo doc --all
+
+    REV=$(git rev-parse --short HEAD)
+    cd target/doc
+    git init
+    git remote add upstream "https://$GH_TOKEN@github.com/elastic-rs/elastic.git"
+    git config user.name "elastic-rs"
+    git config user.email "travis@elastic.rs"
+    git add -A .
+    git commit -qm "Build docs at ${TRAVIS_REPO_SLUG}@${REV}"
+
+    echo "Pushing gh-pages to GitHub"
+    git push -q upstream HEAD:refs/heads/gh-pages --force
 fi
-
-cd ../../
-cargo doc --all
-
-REV=$(git rev-parse --short HEAD)
-cd target/doc
-git init
-git remote add upstream "https://$GH_TOKEN@github.com/elastic-rs/elastic.git"
-git config user.name "elastic-rs"
-git config user.email "travis@elastic.rs"
-git add -A .
-git commit -qm "Build docs at ${TRAVIS_REPO_SLUG}@${REV}"
-
-echo "Pushing gh-pages to GitHub"
-git push -q upstream HEAD:refs/heads/gh-pages --force

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -8,3 +8,23 @@ cargo build --all
 
 cd ../tests/run
 cargo run
+
+# if [ "$TRAVIS_BRANCH" != "master" ]; then
+#     echo "ignoring doc upload on non-master branch"
+#     exit 0
+# fi
+
+cd ../../
+cargo doc --all
+
+REV=$(git rev-parse --short HEAD)
+cd target/doc
+git init
+git remote add upstream "https://$GH_TOKEN@github.com/elastic-rs/elastic.git"
+git config user.name "elastic-rs"
+git config user.email "travis@elastic.rs"
+git add -A .
+git commit -qm "Build docs at ${TRAVIS_REPO_SLUG}@${REV}"
+
+echo "Pushing gh-pages to GitHub"
+git push -q upstream HEAD:refs/heads/gh-pages --force

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -9,10 +9,10 @@ cargo build --all
 cd ../tests/run
 cargo run
 
-# if [ "$TRAVIS_BRANCH" != "master" ]; then
-#     echo "ignoring doc upload on non-master branch"
-#     exit 0
-# fi
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+    echo "ignoring doc upload on non-master branch"
+    exit 0
+fi
 
 cd ../../
 cargo doc --all

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -1,16 +1,10 @@
-set -ex
+#!/bin/bash
 
-cargo test --verbose --all
-cargo bench --verbose --all
-
-cd benches
-cargo build --all
-
-cd ../tests/run
-cargo run
+set -o errexit -o nounset
 
 if [ "$TRAVIS_BRANCH" = "master" ]; then
-    cd ../../
+    echo "uploading crate docs"
+
     cargo doc --all
 
     REV=$(git rev-parse --short HEAD)
@@ -25,3 +19,12 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
     echo "Pushing gh-pages to GitHub"
     git push -q upstream HEAD:refs/heads/gh-pages --force
 fi
+
+cargo test --verbose --all
+cargo bench --verbose --all
+
+cd benches
+cargo build --all
+
+cd ../tests/run
+cargo run

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -2,6 +2,8 @@
 
 set -o errexit -o nounset
 
+echo $TRAVIS_BRANCH
+
 if [ "$TRAVIS_BRANCH" = "master" ]; then
     echo "uploading crate docs"
 

--- a/examples/async_raw_sample/src/body/request.rs
+++ b/examples/async_raw_sample/src/body/request.rs
@@ -50,7 +50,7 @@ impl Stream for FileChunkStream {
 /// The second item is the async body to use in the request.
 pub fn mapped_file<P>
     (path: P)
-     -> Result<(impl Future<Item = (), Error = Error> + Send, FileBody), IoError>
+     -> (impl Future<Item = (), Error = Error> + Send, FileBody)
     where P: AsRef<Path> + Send + 'static
 {
     let (tx, rx) = FileBody::pair();
@@ -67,7 +67,7 @@ pub fn mapped_file<P>
 
     let tx_future = tx_future.map(|_| ());
 
-    Ok((tx_future, rx))
+    (tx_future, rx)
 }
 
 // mmap a file and push its chunks into a queue

--- a/examples/async_raw_sample/src/main.rs
+++ b/examples/async_raw_sample/src/main.rs
@@ -64,7 +64,7 @@ fn send_request(url: &'static str,
                 pool: CpuPool)
                 -> impl Future<Item = BulkResponse, Error = Error> {
     // Get a future to buffer a bulk file
-    let (buffer_request_body, request_body) = body::request::mapped_file("./data/accounts.json").unwrap();
+    let (buffer_request_body, request_body) = body::request::mapped_file("./data/accounts.json");
     let buffer_request_body = pool.spawn(buffer_request_body);
 
     // Build a Bulk request


### PR DESCRIPTION
Upload crate docs on the `master` branch. This should be more helpful for times when `master` diverges significantly from what's on `crates.io`, as it is now.