### PR TITLE
Hide `elastic_types` impl details better

### DIFF
--- a/examples/account_sample/src/main.rs
+++ b/examples/account_sample/src/main.rs
@@ -9,7 +9,6 @@ extern crate elastic_derive;
 #[macro_use]
 extern crate quick_error;
 
-extern crate serde;
 #[macro_use]
 extern crate serde_json;
 extern crate elastic;

--- a/examples/account_sample/src/model/account.rs
+++ b/examples/account_sample/src/model/account.rs
@@ -5,7 +5,7 @@
 //! Field serialisation and mapping is all handled in the same place
 //! so it's always in sync.
 
-use elastic::types::prelude::{FieldType, KeywordFieldType, Text, DefaultTextMapping, TextMapping,
+use elastic::types::prelude::{KeywordFieldType, Text, DefaultTextMapping, TextMapping,
                               Keyword, DefaultKeywordMapping, DocumentType};
 
 /// Our main model; an account in the bank.
@@ -27,11 +27,6 @@ pub struct Account {
 /// Get the indexed document type name.
 pub fn name() -> &'static str {
     Account::name()
-}
-
-/// Get the strongly typed document mapping.
-pub fn mapping() -> AccountMapping {
-    Account::mapping()
 }
 
 // We're using type aliases to make the `Account` definition more ergonomic.
@@ -75,7 +70,7 @@ impl TextMapping for EmailMapping {
 #[cfg(test)]
 mod tests {
     use serde_json;
-    use elastic::types::prelude::IndexDocumentMapping;
+    use elastic::types::prelude::DocumentType;
     use super::{mapping, Account};
 
     #[test]
@@ -101,7 +96,7 @@ mod tests {
 
     #[test]
     fn serialise_mapping() {
-        let ser = serde_json::to_value(&IndexDocumentMapping::from(mapping())).unwrap();
+        let ser = serde_json::to_value(&Account::index_mapping()).unwrap();
 
         let expected = json!({
             "properties":{

--- a/examples/account_sample/src/model/account.rs
+++ b/examples/account_sample/src/model/account.rs
@@ -71,7 +71,7 @@ impl TextMapping for EmailMapping {
 mod tests {
     use serde_json;
     use elastic::types::prelude::DocumentType;
-    use super::{mapping, Account};
+    use super::*;
 
     #[test]
     fn deserialize() {

--- a/examples/account_sample/src/model/index.rs
+++ b/examples/account_sample/src/model/index.rs
@@ -6,7 +6,7 @@
 
 use serde_json::Value;
 use elastic::client::requests::Index;
-use elastic::types::prelude::{IndexDocumentMapping, FieldType};
+use elastic::types::prelude::DocumentType;
 use super::account::{self, Account};
 
 /// Get the name of the bank index.
@@ -44,7 +44,7 @@ pub fn body() -> Value {
             }
         },
         "mappings": {
-            account::name(): IndexDocumentMapping::from(Account::mapping())
+            Account::name(): Account::index_mapping()
         }
     })
 }

--- a/examples/async_raw_sample/src/body/request.rs
+++ b/examples/async_raw_sample/src/body/request.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::path::Path;
-use std::io::Error as IoError;
 
 use tokio_proto::streaming::Body as BodyStream;
 use futures::{IntoFuture, Future, Stream, Sink, Poll, Async};

--- a/src/elastic/src/client/requests/document_put_mapping.rs
+++ b/src/elastic/src/client/requests/document_put_mapping.rs
@@ -17,7 +17,7 @@ use client::requests::params::{Index, Type};
 use client::requests::endpoints::IndicesPutMappingRequest;
 use client::requests::raw::RawRequestInner;
 use client::responses::CommandResponse;
-use types::document::{FieldType, DocumentType, IndexDocumentMapping};
+use types::document::DocumentType;
 
 /** 
 A [put mapping request][docs-mapping] builder that can be configured before sending.
@@ -107,7 +107,7 @@ impl<TDocument> PutMappingRequestInner<TDocument>
     where TDocument: DocumentType
 {
     fn into_sync_request(self) -> Result<IndicesPutMappingRequest<'static, Vec<u8>>> {
-        let body = serde_json::to_vec(&IndexDocumentMapping::from(TDocument::mapping())).map_err(error::request)?;
+        let body = serde_json::to_vec(&TDocument::index_mapping()).map_err(error::request)?;
 
         Ok(IndicesPutMappingRequest::for_index_ty(self.index, self.ty, body))
     }

--- a/src/elastic/src/client/requests/index_create.rs
+++ b/src/elastic/src/client/requests/index_create.rs
@@ -91,7 +91,7 @@ impl<TSender> Client<TSender>
             }
         },
         "mappings": {
-            MyType::name(): IndexDocumentMapping::from(MyType::mapping())
+            MyType::name(): MyType::index_mapping()
         }
     });
 

--- a/src/elastic/src/types.rs
+++ b/src/elastic/src/types.rs
@@ -117,7 +117,7 @@ You can use the `IndexDocumentMapping` type wrapper to serialise the mapping for
 # fn run() -> Result<(), Box<::std::error::Error>> {
 # #[derive(Serialize, Deserialize, ElasticType)]
 # struct MyType {}
-let doc = IndexDocumentMapping::from(MyType::mapping());
+let doc = MyType::index_mapping();
 
 let mapping = serde_json::to_string(&doc)?;
 # Ok(())
@@ -142,7 +142,7 @@ This will produce the following JSON:
 #     title: String,
 #     timestamp: Date<DefaultDateMapping<EpochMillis>>
 # }
-# let mapping = serde_json::to_string(&IndexDocumentMapping::from(MyType::mapping()))?;
+# let mapping = serde_json::to_string(&MyType::index_mapping())?;
 # let expected = json_str!(
 {
     "properties": {
@@ -238,7 +238,7 @@ Serialising `MyType`s mapping will produce the following json:
 # }
 # fn main() { run().unwrap() }
 # fn run() -> Result<(), Box<::std::error::Error>> {
-# let mapping = serde_json::to_string(&IndexDocumentMapping::from(MyType::mapping()))?;
+# let mapping = serde_json::to_string(&MyType::index_mapping())?;
 # let expected = json_str!(
 {
     "properties": {

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -46,7 +46,7 @@ type Timestamp = Date<DefaultDateMapping<EpochMillis>>;
 You can then get the mapping for your type as `json`:
 
 ```rust
-let mapping = serde_json::to_string(&IndexDocumentMapping::from(MyType::mapping())).unwrap();
+let mapping = serde_json::to_string(&MyType::index_mapping()).unwrap();
 ```
 
 Which looks like:

--- a/src/types/benches/boolean/mod.rs
+++ b/src/types/benches/boolean/mod.rs
@@ -1,3 +1,4 @@
+use elastic_types;
 use elastic_types::prelude::*;
 use boolean_fixtures::*;
 
@@ -5,5 +6,5 @@ use test::Bencher;
 
 #[bench]
 fn mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyBooleanMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyBooleanMapping).unwrap());
 }

--- a/src/types/benches/date/mod.rs
+++ b/src/types/benches/date/mod.rs
@@ -1,4 +1,5 @@
 use serde_json;
+use elastic_types;
 use elastic_types::prelude::*;
 use date_fixtures::*;
 
@@ -30,5 +31,5 @@ fn fmt_epoch(b: &mut Bencher) {
 
 #[bench]
 fn mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyDateMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyDateMapping).unwrap());
 }

--- a/src/types/benches/geo_point/mod.rs
+++ b/src/types/benches/geo_point/mod.rs
@@ -1,5 +1,6 @@
 use serde_json;
 use georust::{Point, Coordinate};
+use elastic_types;
 use elastic_types::prelude::*;
 use geo_point_fixtures::*;
 
@@ -83,5 +84,5 @@ fn fmt_array(b: &mut Bencher) {
 
 #[bench]
 fn mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyGeoPointMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyGeoPointMapping).unwrap());
 }

--- a/src/types/benches/geo_shape/mod.rs
+++ b/src/types/benches/geo_shape/mod.rs
@@ -1,3 +1,4 @@
+use elastic_types;
 use elastic_types::prelude::*;
 use geo_shape_fixtures::*;
 
@@ -5,5 +6,5 @@ use test::Bencher;
 
 #[bench]
 fn mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyGeoShapeMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyGeoShapeMapping).unwrap());
 }

--- a/src/types/benches/ip/mod.rs
+++ b/src/types/benches/ip/mod.rs
@@ -1,4 +1,5 @@
 use serde_json;
+use elastic_types;
 use elastic_types::prelude::*;
 use ::ip_fixtures::*;
 
@@ -7,6 +8,6 @@ use test::Bencher;
 #[bench]
 fn mapping(b: &mut Bencher) {
     b.iter(|| {
-        standalone_field_ser(MyIpMapping).unwrap()
+        elastic_types::derive::standalone_field_ser(MyIpMapping).unwrap()
     });
 }

--- a/src/types/benches/mod.rs
+++ b/src/types/benches/mod.rs
@@ -9,6 +9,8 @@ extern crate geojson;
 extern crate test;
 
 extern crate elastic_types;
+#[macro_use]
+extern crate elastic_types_derive;
 
 pub mod date_fixtures {
     use elastic_types::prelude::*;
@@ -564,6 +566,14 @@ pub mod object_fixtures {
     use chrono::{DateTime, Utc};
     use elastic_types::prelude::*;
 
+    #[derive(ElasticType)]
+    #[elastic(mapping = "MySmlMapping")]
+    pub struct MySmlType {
+        integer: i32,
+        string: String,
+        date: DateTime<Utc>,
+    }
+
     #[derive(Default, Clone)]
     pub struct MySmlMapping;
     impl DocumentMapping for MySmlMapping {
@@ -571,20 +581,14 @@ pub mod object_fixtures {
             "ty"
         }
     }
-    impl PropertiesMapping for MySmlMapping {
-        fn props_len() -> usize {
-            3
-        }
 
-        fn serialize_props<S>(state: &mut S) -> Result<(), S::Error>
-            where S: SerializeStruct
-        {
-            try!(field_ser(state, "integer", i32::mapping()));
-            try!(field_ser(state, "string", String::mapping()));
-            try!(field_ser(state, "date", DateTime::<Utc>::mapping()));
-
-            Ok(())
-        }
+    #[derive(ElasticType)]
+    #[elastic(mapping = "MyMedMapping")]
+    pub struct MyMedType {
+        integer: i32,
+        string: String,
+        date: DateTime<Utc>,
+        field: MySmlType,
     }
 
     #[derive(Default, Clone)]
@@ -594,21 +598,14 @@ pub mod object_fixtures {
             "ty"
         }
     }
-    impl PropertiesMapping for MyMedMapping {
-        fn props_len() -> usize {
-            4
-        }
 
-        fn serialize_props<S>(state: &mut S) -> Result<(), S::Error>
-            where S: SerializeStruct
-        {
-            try!(field_ser(state, "integer", i32::mapping()));
-            try!(field_ser(state, "string", String::mapping()));
-            try!(field_ser(state, "date", DateTime::<Utc>::mapping()));
-            try!(field_ser(state, "field", MySmlMapping));
-
-            Ok(())
-        }
+    #[derive(ElasticType)]
+    #[elastic(mapping = "MyLrgMapping")]
+    pub struct MyLrgType {
+        integer: i32,
+        string: String,
+        date: DateTime<Utc>,
+        field: MyMedType,
     }
 
     #[derive(Default, Clone)]
@@ -616,22 +613,6 @@ pub mod object_fixtures {
     impl DocumentMapping for MyLrgMapping {
         fn name() -> &'static str {
             "ty"
-        }
-    }
-    impl PropertiesMapping for MyLrgMapping {
-        fn props_len() -> usize {
-            4
-        }
-
-        fn serialize_props<S>(state: &mut S) -> Result<(), S::Error>
-            where S: SerializeStruct
-        {
-            try!(field_ser(state, "integer", i32::mapping()));
-            try!(field_ser(state, "string", String::mapping()));
-            try!(field_ser(state, "date", DateTime::<Utc>::mapping()));
-            try!(field_ser(state, "field", MyMedMapping));
-
-            Ok(())
         }
     }
 }

--- a/src/types/benches/number/mod.rs
+++ b/src/types/benches/number/mod.rs
@@ -1,3 +1,4 @@
+use elastic_types;
 use elastic_types::prelude::*;
 use number_fixtures::*;
 
@@ -5,5 +6,5 @@ use test::Bencher;
 
 #[bench]
 fn mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyIntegerMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyIntegerMapping).unwrap());
 }

--- a/src/types/benches/object/mod.rs
+++ b/src/types/benches/object/mod.rs
@@ -5,30 +5,30 @@ use test::Bencher;
 
 #[bench]
 fn mapping_sml(b: &mut Bencher) {
-    b.iter(|| serde_json::to_string(&IndexDocumentMapping::from(MySmlMapping)).unwrap());
+    b.iter(|| serde_json::to_string(&MySmlType::index_mapping()).unwrap());
 }
 
 #[bench]
 fn mapping_med(b: &mut Bencher) {
-    b.iter(|| serde_json::to_string(&IndexDocumentMapping::from(MyMedMapping)).unwrap());
+    b.iter(|| serde_json::to_string(&MyMedType::index_mapping()).unwrap());
 }
 
 #[bench]
 fn mapping_lrg(b: &mut Bencher) {
-    b.iter(|| serde_json::to_string(&IndexDocumentMapping::from(MyLrgMapping)).unwrap());
+    b.iter(|| serde_json::to_string(&MyLrgType::index_mapping()).unwrap());
 }
 
 #[bench]
 fn mapping_value_sml(b: &mut Bencher) {
-    b.iter(|| serde_json::to_value(&IndexDocumentMapping::from(MySmlMapping)));
+    b.iter(|| serde_json::to_value(&MySmlType::index_mapping()));
 }
 
 #[bench]
 fn mapping_value_med(b: &mut Bencher) {
-    b.iter(|| serde_json::to_value(&IndexDocumentMapping::from(MyMedMapping)));
+    b.iter(|| serde_json::to_value(&MyMedType::index_mapping()));
 }
 
 #[bench]
 fn mapping_value_lrg(b: &mut Bencher) {
-    b.iter(|| serde_json::to_value(&IndexDocumentMapping::from(MyLrgMapping)));
+    b.iter(|| serde_json::to_value(&MyLrgType::index_mapping()));
 }

--- a/src/types/benches/string/mod.rs
+++ b/src/types/benches/string/mod.rs
@@ -1,3 +1,4 @@
+use elastic_types;
 use elastic_types::prelude::*;
 use string_fixtures::*;
 
@@ -5,10 +6,10 @@ use test::Bencher;
 
 #[bench]
 fn keyword_mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyKeywordMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyKeywordMapping).unwrap());
 }
 
 #[bench]
 fn text_mapping(b: &mut Bencher) {
-    b.iter(|| standalone_field_ser(MyTextMapping).unwrap());
+    b.iter(|| elastic_types::derive::standalone_field_ser(MyTextMapping).unwrap());
 }

--- a/src/types/src/boolean/impls.rs
+++ b/src/types/src/boolean/impls.rs
@@ -21,13 +21,13 @@ let boolean = Boolean::<DefaultBooleanMapping>::new(true);
 ```
 */
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct Boolean<M> where M: BooleanMapping {
+pub struct Boolean<TMapping> where TMapping: BooleanMapping {
     value: bool,
-    _m: PhantomData<M>,
+    _m: PhantomData<TMapping>,
 }
 
-impl<M> Boolean<M>
-    where M: BooleanMapping
+impl<TMapping> Boolean<TMapping>
+    where TMapping: BooleanMapping
 {
     /**
     Creates a new `Boolean` with the given mapping.
@@ -41,7 +41,7 @@ impl<M> Boolean<M>
     let boolean = Boolean::<DefaultBooleanMapping>::new(false);
     ```
     */
-    pub fn new<I>(boolean: I) -> Boolean<M>
+    pub fn new<I>(boolean: I) -> Boolean<TMapping>
         where I: Into<bool>
     {
         Boolean {
@@ -72,19 +72,19 @@ impl<M> Boolean<M>
     # }
     ```
     */
-    pub fn remap<MInto>(boolean: Boolean<M>) -> Boolean<MInto>
-        where MInto: BooleanMapping
+    pub fn remap<TNewMapping>(boolean: Boolean<TMapping>) -> Boolean<TNewMapping>
+        where TNewMapping: BooleanMapping
     {
-        Boolean::<MInto>::new(boolean.value)
+        Boolean::<TNewMapping>::new(boolean.value)
     }
 }
 
-impl<M> BooleanFieldType<M> for Boolean<M> where M: BooleanMapping {}
+impl<TMapping> BooleanFieldType<TMapping> for Boolean<TMapping> where TMapping: BooleanMapping {}
 
 impl_mapping_type!(bool, Boolean, BooleanMapping);
 
-impl<M> Serialize for Boolean<M>
-    where M: BooleanMapping
+impl<TMapping> Serialize for Boolean<TMapping>
+    where TMapping: BooleanMapping
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -93,36 +93,34 @@ impl<M> Serialize for Boolean<M>
     }
 }
 
-impl<'de, M> Deserialize<'de> for Boolean<M>
-    where M: BooleanMapping
+impl<'de, TMapping> Deserialize<'de> for Boolean<TMapping>
+    where TMapping: BooleanMapping
 {
-    fn deserialize<D>(deserializer: D) -> Result<Boolean<M>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Boolean<TMapping>, D::Error>
         where D: Deserializer<'de>
     {
         #[derive(Default)]
-        struct BooleanVisitor<M>
-            where M: BooleanMapping
-        {
-            _m: PhantomData<M>,
+        struct BooleanVisitor<TMapping> {
+            _m: PhantomData<TMapping>,
         }
 
-        impl<'de, M> Visitor<'de> for BooleanVisitor<M>
-            where M: BooleanMapping
+        impl<'de, TMapping> Visitor<'de> for BooleanVisitor<TMapping>
+            where TMapping: BooleanMapping
         {
-            type Value = Boolean<M>;
+            type Value = Boolean<TMapping>;
 
             fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(formatter, "a json boolean")
             }
 
-            fn visit_bool<E>(self, v: bool) -> Result<Boolean<M>, E>
+            fn visit_bool<E>(self, v: bool) -> Result<Boolean<TMapping>, E>
                 where E: Error
             {
-                Ok(Boolean::<M>::new(v))
+                Ok(Boolean::<TMapping>::new(v))
             }
         }
 
-        deserializer.deserialize_any(BooleanVisitor::<M>::default())
+        deserializer.deserialize_any(BooleanVisitor::<TMapping>::default())
     }
 }
 

--- a/src/types/src/boolean/mapping.rs
+++ b/src/types/src/boolean/mapping.rs
@@ -1,22 +1,7 @@
 /*! Mapping for the Elasticsearch `boolean` type. */
 
-use serde::{Serialize, Serializer};
-use serde::ser::SerializeStruct;
-use private::field::{DocumentField, FieldMapping, SerializeField};
-use document::FieldType;
-
 /** A field that will be mapped as a `boolean`. */
-pub trait BooleanFieldType<M> {}
-
-impl<T, M> FieldType<M, BooleanFormat> for T
-    where M: BooleanMapping,
-          T: BooleanFieldType<M> + Serialize
-{
-}
-
-#[doc(hidden)]
-#[derive(Default)]
-pub struct BooleanFormat;
+pub trait BooleanFieldType<TMapping> {}
 
 /**
 The base requirements for mapping a `boolean` type.
@@ -117,51 +102,62 @@ pub trait BooleanMapping
     }
 }
 
-impl<T> FieldMapping<BooleanFormat> for T
-    where T: BooleanMapping
-{
-    fn data_type() -> &'static str {
-        "boolean"
-    }
-}
-
-impl<T> SerializeField<BooleanFormat> for T
-    where T: BooleanMapping
-{
-    type Field = DocumentField<T, BooleanFormat>;
-}
-
-impl<T> Serialize for DocumentField<T, BooleanFormat>
-    where T: FieldMapping<BooleanFormat> + BooleanMapping
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        let mut state = try!(serializer.serialize_struct("mapping", 6));
-
-        try!(state.serialize_field("type", T::data_type()));
-
-        ser_field!(state, "boost", T::boost());
-        ser_field!(state, "doc_values", T::doc_values());
-        ser_field!(state, "index", T::index());
-        ser_field!(state, "store", T::store());
-        ser_field!(state, "null_value", T::null_value());
-
-        state.end()
-    }
-}
-
 /** Default mapping for `bool`. */
 #[derive(PartialEq, Debug, Default, Clone, Copy)]
 pub struct DefaultBooleanMapping;
 impl BooleanMapping for DefaultBooleanMapping {}
+
+mod private {
+    use serde::{Serialize, Serializer};
+    use serde::ser::SerializeStruct;
+    use private::field::{FieldType, DocumentField, FieldMapping};
+    use super::{BooleanFieldType, BooleanMapping};
+
+    #[derive(Default)]
+    pub struct BooleanPivot;
+
+    impl<TField, TMapping> FieldType<TMapping, BooleanPivot> for TField
+        where TMapping: BooleanMapping,
+              TField: BooleanFieldType<TMapping> + Serialize
+    { }
+
+    impl<TMapping> FieldMapping<BooleanPivot> for TMapping
+        where TMapping: BooleanMapping
+    {
+        type DocumentField = DocumentField<TMapping, BooleanPivot>;
+
+        fn data_type() -> &'static str {
+            "boolean"
+        }
+    }
+
+    impl<TMapping> Serialize for DocumentField<TMapping, BooleanPivot>
+        where TMapping: FieldMapping<BooleanPivot> + BooleanMapping
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: Serializer
+        {
+            let mut state = try!(serializer.serialize_struct("mapping", 6));
+
+            try!(state.serialize_field("type", TMapping::data_type()));
+
+            ser_field!(state, "boost", TMapping::boost());
+            ser_field!(state, "doc_values", TMapping::doc_values());
+            ser_field!(state, "index", TMapping::index());
+            ser_field!(state, "store", TMapping::store());
+            ser_field!(state, "null_value", TMapping::null_value());
+
+            state.end()
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use serde_json;
 
     use prelude::*;
-    use private::field::DocumentField;
+    use private::field::{FieldType, DocumentField};
 
     #[derive(Default, Clone)]
     pub struct MyBooleanMapping;
@@ -189,7 +185,7 @@ mod tests {
 
     #[test]
     fn bool_has_default_mapping() {
-        assert_eq!(DefaultBooleanMapping, bool::mapping());
+        assert_eq!(DefaultBooleanMapping, bool::field_mapping());
     }
 
     #[test]

--- a/src/types/src/date/format.rs
+++ b/src/types/src/date/format.rs
@@ -35,8 +35,8 @@ impl DateValue {
     }
 }
 
-impl<F> From<FormattableDateValue<F>> for DateValue {
-    fn from(date: FormattableDateValue<F>) -> Self {
+impl<TFormat> From<FormattableDateValue<TFormat>> for DateValue {
+    fn from(date: FormattableDateValue<TFormat>) -> Self {
         date.0
     }
 }
@@ -89,35 +89,35 @@ Like `DateValue`, this type is used for binding generics in methods that accept 
 You probably don't need to use it directly except to ensure date formats aren't silently changed.
 */
 #[derive(Debug, Clone, PartialEq)]
-pub struct FormattableDateValue<F>(DateValue, PhantomData<F>);
+pub struct FormattableDateValue<TFormat>(DateValue, PhantomData<TFormat>);
 
-impl<F> FormattableDateValue<F> where F: DateFormat {
+impl<TFormat> FormattableDateValue<TFormat> where TFormat: DateFormat {
     /** Format the wrapped date value using the generic format. */
     pub fn format<'a>(&'a self) -> FormattedDate<'a> {
-        F::format(&self.0)
+        TFormat::format(&self.0)
     }
 
     /** Parse a date value using the generic format. */
     pub fn parse(date: &str) -> Result<Self, ParseError> {
-        let date = F::parse(date)?;
+        let date = TFormat::parse(date)?;
 
         Ok(FormattableDateValue::from(date))
     }
 }
 
-impl<F> From<DateValue> for FormattableDateValue<F> {
+impl<TFormat> From<DateValue> for FormattableDateValue<TFormat> {
     fn from(date: DateValue) -> Self {
         FormattableDateValue(date.into(), PhantomData)
     }
 }
 
-impl<F> Borrow<ChronoDateTime> for FormattableDateValue<F> {
+impl<TFormat> Borrow<ChronoDateTime> for FormattableDateValue<TFormat> {
     fn borrow(&self) -> &ChronoDateTime {
         self.0.borrow()
     }
 }
 
-impl<F> PartialEq<ChronoDateTime> for FormattableDateValue<F> {
+impl<TFormat> PartialEq<ChronoDateTime> for FormattableDateValue<TFormat> {
     fn eq(&self, other: &ChronoDateTime) -> bool {
         PartialEq::eq(&self.0, other)
     }
@@ -127,12 +127,12 @@ impl<F> PartialEq<ChronoDateTime> for FormattableDateValue<F> {
     }
 }
 
-impl<F> PartialEq<FormattableDateValue<F>> for ChronoDateTime {
-    fn eq(&self, other: &FormattableDateValue<F>) -> bool {
+impl<TFormat> PartialEq<FormattableDateValue<TFormat>> for ChronoDateTime {
+    fn eq(&self, other: &FormattableDateValue<TFormat>) -> bool {
         PartialEq::eq(self, &other.0)
     }
 
-    fn ne(&self, other: &FormattableDateValue<F>) -> bool {
+    fn ne(&self, other: &FormattableDateValue<TFormat>) -> bool {
         PartialEq::ne(self, &other.0)
     }
 }

--- a/src/types/src/date/mapping.rs
+++ b/src/types/src/date/mapping.rs
@@ -1,31 +1,13 @@
 /*! Mapping for the Elasticsearch `date` type. */
 
 use std::marker::PhantomData;
-use serde::{Serialize, Serializer};
-use serde::ser::SerializeStruct;
 use super::{DateFormat, DefaultDateFormat, FormattableDateValue, Date};
-use private::field::{DocumentField, FieldMapping, SerializeField};
-use document::FieldType;
 
 /** A field that will be mapped as a `date`. */
-pub trait DateFieldType<M> 
-    where Self: Into<FormattableDateValue<M::Format>>,
-          M: DateMapping
+pub trait DateFieldType<TMapping> 
+    where Self: Into<FormattableDateValue<TMapping::Format>>,
+          TMapping: DateMapping
 { }
-
-impl<T, M> FieldType<M, DateFormatWrapper<M::Format>> for T
-    where T: DateFieldType<M> + Serialize,
-          T: Into<FormattableDateValue<M::Format>>,
-          M: DateMapping
-{ }
-
-#[doc(hidden)]
-#[derive(Default)]
-pub struct DateFormatWrapper<F>
-    where F: DateFormat
-{
-    _f: PhantomData<F>,
-}
 
 /**
 The base requirements for mapping a `date` type.
@@ -75,7 +57,7 @@ This will produce the following mapping:
 #     }
 # }
 # fn main() {
-# let mapping = standalone_field_ser(MyDateMapping).unwrap();
+# let mapping = elastic_types::derive::standalone_field_ser(MyDateMapping).unwrap();
 # let json = json_str!(
 {
     "type": "date",
@@ -177,58 +159,70 @@ pub trait DateMapping
     }
 }
 
-impl<T, F> FieldMapping<DateFormatWrapper<F>> for T
-    where T: DateMapping<Format = F>,
-          F: DateFormat
-{
-    fn data_type() -> &'static str {
-        "date"
-    }
-}
-
-impl<T, F> SerializeField<DateFormatWrapper<F>> for T
-    where T: DateMapping<Format = F>,
-          F: DateFormat
-{
-    type Field = DocumentField<T, DateFormatWrapper<F>>;
-}
-
-impl<T, F> Serialize for DocumentField<T, DateFormatWrapper<F>>
-    where T: FieldMapping<DateFormatWrapper<F>> + DateMapping<Format = F>,
-          F: DateFormat
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        let mut state = try!(serializer.serialize_struct("mapping", 9));
-
-        try!(state.serialize_field("type", T::data_type()));
-        try!(state.serialize_field("format", T::Format::name()));
-
-        ser_field!(state, "boost", T::boost());
-        ser_field!(state, "doc_values", T::doc_values());
-        ser_field!(state, "include_in_all", T::include_in_all());
-        ser_field!(state, "index", T::index());
-        ser_field!(state, "store", T::store());
-        ser_field!(state, "ignore_malformed", T::ignore_malformed());
-        ser_field!(state, "null_value", T::null_value());
-
-        state.end()
-    }
-}
-
 /** Default mapping for `date`. */
 #[derive(PartialEq, Debug, Default, Clone, Copy)]
-pub struct DefaultDateMapping<F = DefaultDateFormat>
-    where F: DateFormat
+pub struct DefaultDateMapping<TFormat = DefaultDateFormat>
+    where TFormat: DateFormat
 {
-    _f: PhantomData<F>,
+    _f: PhantomData<TFormat>,
 }
 
-impl<F> DateMapping for DefaultDateMapping<F>
-    where F: DateFormat
+impl<TFormat> DateMapping for DefaultDateMapping<TFormat>
+    where TFormat: DateFormat
 {
-    type Format = F;
+    type Format = TFormat;
+}
+
+mod private {
+    use serde::{Serialize, Serializer};
+    use serde::ser::SerializeStruct;
+    use date::{DateFormat, FormattableDateValue};
+    use private::field::{FieldType, DocumentField, FieldMapping};
+    use super::{DateFieldType, DateMapping};
+
+    impl<TField, TMapping> FieldType<TMapping, DatePivot> for TField
+        where TField: DateFieldType<TMapping> + Serialize,
+            TField: Into<FormattableDateValue<TMapping::Format>>,
+            TMapping: DateMapping
+    { }
+
+    #[derive(Default)]
+    pub struct DatePivot;
+
+    impl<TMapping, TFormat> FieldMapping<DatePivot> for TMapping
+        where TMapping: DateMapping<Format = TFormat>,
+              TFormat: DateFormat
+    {
+        type DocumentField = DocumentField<TMapping, DatePivot>;
+
+        fn data_type() -> &'static str {
+            "date"
+        }
+    }
+
+    impl<TMapping, TFormat> Serialize for DocumentField<TMapping, DatePivot>
+        where TMapping: FieldMapping<DatePivot> + DateMapping<Format = TFormat>,
+            TFormat: DateFormat
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: Serializer
+        {
+            let mut state = try!(serializer.serialize_struct("mapping", 9));
+
+            try!(state.serialize_field("type", TMapping::data_type()));
+            try!(state.serialize_field("format", TMapping::Format::name()));
+
+            ser_field!(state, "boost", TMapping::boost());
+            ser_field!(state, "doc_values", TMapping::doc_values());
+            ser_field!(state, "include_in_all", TMapping::include_in_all());
+            ser_field!(state, "index", TMapping::index());
+            ser_field!(state, "store", TMapping::store());
+            ser_field!(state, "ignore_malformed", TMapping::ignore_malformed());
+            ser_field!(state, "null_value", TMapping::null_value());
+
+            state.end()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -237,7 +231,7 @@ mod tests {
     use chrono::{DateTime, Utc};
 
     use prelude::*;
-    use private::field::DocumentField;
+    use private::field::{FieldType, DocumentField};
 
     #[derive(Default, Clone)]
     pub struct MyDateMapping;
@@ -275,7 +269,7 @@ mod tests {
 
     #[test]
     fn datetime_has_default_mapping() {
-        assert_eq!(DefaultDateMapping::<ChronoFormat>::default(), DateTime::<Utc>::mapping());
+        assert_eq!(DefaultDateMapping::<ChronoFormat>::default(), DateTime::<Utc>::field_mapping());
     }
 
     #[test]

--- a/src/types/src/derive.rs
+++ b/src/types/src/derive.rs
@@ -1,12 +1,19 @@
-/*! Functions that are exported and used by `elastic_types_derive`. */
+/*!
+Functions that are exported and used by `elastic_types_derive`.
 
+This module is 'private' and should only be consumed by `elastic_types_derive`.
+Its contents aren't subject to SemVer.
+*/
+
+use serde_json;
+use serde::Serialize;
 use chrono::{DateTime, Utc};
 use chrono::format::{self, Parsed};
 
-use private::field::FieldMapping;
+use private::field::{FieldType, FieldMapping, DocumentField};
 
 pub use date::{DateFormat, DateValue, ParseError, FormattedDate};
-pub use document::{DocumentType, FieldType, field_ser};
+pub use document::DocumentType;
 pub use document::mapping::{DocumentMapping, PropertiesMapping};
 
 pub use chrono::format::{Item, Pad, Numeric, Fixed};
@@ -14,12 +21,37 @@ pub use serde::ser::SerializeStruct;
 
 /** Get the mapping for a field. */
 #[inline]
-pub fn mapping<T, M, F>() -> M
-    where T: FieldType<M, F>,
-          M: FieldMapping<F>,
-          F: Default
+pub fn mapping<TField, TMapping, TPivot>() -> TMapping
+    where TField: FieldType<TMapping, TPivot>,
+          TMapping: FieldMapping<TPivot>,
+          TPivot: Default
 {
-    T::mapping()
+    TMapping::default()
+}
+
+/** Serialise a field mapping as a field using the given serialiser. */
+#[inline]
+pub fn field_ser<S, TMapping, TPivot>(state: &mut S, field: &'static str, _: TMapping) -> Result<(), S::Error>
+    where S: SerializeStruct,
+          TMapping: FieldMapping<TPivot>,
+          TPivot: Default,
+          DocumentField<TMapping, TPivot>: Serialize,
+{
+    state.serialize_field(field, &DocumentField::<TMapping, TPivot>::default())
+}
+
+/**
+Serialize a field individually.
+
+This method isn't intended to be used publicly, but is useful in the docs.
+*/
+#[inline]
+pub fn standalone_field_ser<TMapping, TPivot>(_: TMapping) -> Result<String, serde_json::Error>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default,
+          DocumentField<TMapping, TPivot>: Serialize,
+{
+    serde_json::to_string(&DocumentField::<TMapping, TPivot>::default())
 }
 
 /** Parse a date string using an owned slice of items. */

--- a/src/types/src/document/impls.rs
+++ b/src/types/src/document/impls.rs
@@ -2,9 +2,8 @@ use std::sync::{Mutex, RwLock};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 use serde::ser::{Serialize, SerializeStruct};
-use serde_json::{self, Value};
+use serde_json::Value;
 use super::mapping::{DocumentMapping, PropertiesMapping};
-use private::field::FieldMapping;
 
 /**
 The additional fields available to an indexable Elasticsearch type.
@@ -24,30 +23,15 @@ pub trait DocumentType {
     fn name() -> &'static str {
         Self::Mapping::name()
     }
-}
 
-/**
-The base representation of an Elasticsearch data type.
+    /** Get a serialisable instance of the type mapping as a field. */
+    fn field_mapping() -> Self::Mapping {
+        Self::Mapping::default()
+    }
 
-`FieldType` is the main `trait` you need to care about when building your own Elasticsearch types.
-Each type has two generic arguments that help define its mapping:
-
-- A mapping type, which implements `FieldMapping`
-- A format type, which is usually `()`. Types with multiple formats, like `Date`, can use the format in the type definition.
-
-# Links
-
-- [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html)
-*/
-pub trait FieldType<M, F>
-    where M: FieldMapping<F>,
-          F: Default
-{
-    /**
-    Get the mapping for this type.
-    */
-    fn mapping() -> M {
-        M::default()
+    /** Get a serialisable instance of the type mapping as an indexable type */
+    fn index_mapping() -> IndexDocumentMapping<Self::Mapping> {
+        IndexDocumentMapping::default()
     }
 }
 
@@ -189,7 +173,7 @@ impl Serialize for Mappings {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut state = try!(serializer.serialize_struct("mappings", 1));
 
-        try!(state.serialize_field(MyType::name(), &IndexDocumentMapping::from(MyType::mapping())));
+        try!(state.serialize_field(MyType::name(), &MyType::index_mapping()));
 
         state.end()
     }
@@ -227,51 +211,10 @@ impl Serialize for Mappings {
 ```
 */
 #[derive(Default)]
-pub struct IndexDocumentMapping<M>
-    where M: DocumentMapping
+pub struct IndexDocumentMapping<TMapping>
+    where TMapping: DocumentMapping
 {
-    _m: PhantomData<M>,
-}
-
-impl<M> From<M> for IndexDocumentMapping<M>
-    where M: DocumentMapping
-{
-    fn from(_: M) -> Self {
-        IndexDocumentMapping::<M>::default()
-    }
-}
-
-/** Serialise a field mapping as a field using the given serialiser. */
-#[inline]
-pub fn field_ser<S, M, F>(state: &mut S, field: &'static str, _: M) -> Result<(), S::Error>
-    where S: SerializeStruct,
-          M: FieldMapping<F>,
-          F: Default
-{
-    state.serialize_field(field, &M::Field::default())
-}
-
-/** Serialise a document mapping as a field using the given serialiser. */
-#[inline]
-pub fn doc_ser<S, M>(state: &mut S, field: &'static str, _: M) -> Result<(), S::Error>
-    where S: SerializeStruct,
-          M: DocumentMapping
-{
-    state.serialize_field(field, &IndexDocumentMapping::<M>::default())
-}
-
-/**
-Serialize a field individually.
-
-This method isn't intended to be used publicly, but is useful in the docs.
-*/
-#[doc(hidden)]
-#[inline]
-pub fn standalone_field_ser<M, F>(_: M) -> Result<String, serde_json::Error>
-    where M: FieldMapping<F>,
-          F: Default
-{
-    serde_json::to_string(&M::Field::default())
+    _m: PhantomData<TMapping>,
 }
 
 /** Mapping for an anonymous json object. */
@@ -446,12 +389,12 @@ mod tests {
 
     #[test]
     fn derive_custom_type_mapping() {
-        assert_eq!(ManualCustomTypeMapping, CustomType::mapping());
+        assert_eq!(ManualCustomTypeMapping, CustomType::field_mapping());
     }
 
     #[test]
     fn serialise_document() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(SimpleType::mapping())).unwrap();
+        let ser = serde_json::to_string(&SimpleType::index_mapping()).unwrap();
 
         let expected = json_str!({
             "properties":{
@@ -475,48 +418,46 @@ mod tests {
 
     #[test]
     fn serialise_document_borrowed() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(<&'static SimpleType>::mapping())).unwrap();
+        let ser = serde_json::to_string(&<&'static SimpleType>::index_mapping()).unwrap();
 
-        let expected = serde_json::to_string(&IndexDocumentMapping::from(SimpleType::mapping())).unwrap();
+        let expected = serde_json::to_string(&SimpleType::index_mapping()).unwrap();
 
         assert_eq!(expected, ser);
     }
 
     #[test]
     fn serialise_document_mutex() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(Mutex::<SimpleType>::mapping())).unwrap();
+        let ser = serde_json::to_string(&Mutex::<SimpleType>::index_mapping()).unwrap();
 
-        let expected = serde_json::to_string(&IndexDocumentMapping::from(SimpleType::mapping())).unwrap();
+        let expected = serde_json::to_string(&SimpleType::index_mapping()).unwrap();
 
         assert_eq!(expected, ser);
     }
 
     #[test]
     fn serialise_document_rwlock() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(RwLock::<SimpleType>::mapping())).unwrap();
+        let ser = serde_json::to_string(&RwLock::<SimpleType>::index_mapping()).unwrap();
 
-        let expected = serde_json::to_string(&IndexDocumentMapping::from(SimpleType::mapping())).unwrap();
+        let expected = serde_json::to_string(&SimpleType::index_mapping()).unwrap();
 
         assert_eq!(expected, ser);
     }
 
     #[test]
     fn serialise_document_cow() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(Cow::<'static, SimpleType>::mapping())).unwrap();
+        let ser = serde_json::to_string(&Cow::<'static, SimpleType>::index_mapping()).unwrap();
 
-        let expected = serde_json::to_string(&IndexDocumentMapping::from(SimpleType::mapping())).unwrap();
+        let expected = serde_json::to_string(&SimpleType::index_mapping()).unwrap();
 
         assert_eq!(expected, ser);
     }
 
     #[test]
     fn serialise_document_with_no_props() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(NoProps::mapping())).unwrap();
+        let ser = serde_json::to_string(&NoProps::index_mapping()).unwrap();
 
         let expected = json_str!({
-            "properties": {
-
-            }
+            "properties": {}
         });
 
         assert_eq!(expected, ser);
@@ -524,7 +465,7 @@ mod tests {
 
     #[test]
     fn serialise_document_for_custom_mapping() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(CustomType::mapping())).unwrap();
+        let ser = serde_json::to_string(&CustomType::index_mapping()).unwrap();
 
         let expected = json_str!({
             "properties": {
@@ -542,7 +483,7 @@ mod tests {
 
     #[test]
     fn serialise_document_for_value() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(Value::mapping())).unwrap();
+        let ser = serde_json::to_string(&Value::index_mapping()).unwrap();
 
         let expected = json_str!({
             "properties": {}
@@ -553,7 +494,7 @@ mod tests {
 
     #[test]
     fn serialise_mapping_with_wrapped_types() {
-        let ser = serde_json::to_string(&IndexDocumentMapping::from(Wrapped::mapping())).unwrap();
+        let ser = serde_json::to_string(&Wrapped::index_mapping()).unwrap();
 
         let expected = json_str!({
             "properties": {

--- a/src/types/src/document/mod.rs
+++ b/src/types/src/document/mod.rs
@@ -57,7 +57,7 @@ This will produce the following field mapping:
 #   pub my_num: i32
 # }
 # fn main() {
-# let mapping = standalone_field_ser(MyTypeMapping).unwrap();
+# let mapping = elastic_types::derive::standalone_field_ser(MyTypeMapping).unwrap();
 # let json = json_str!(
 {
     "type": "nested",
@@ -151,7 +151,7 @@ This will produce the following field mapping:
 #   fn data_type() -> &'static str { OBJECT_DATATYPE }
 # }
 # fn main() {
-# let mapping = standalone_field_ser(MyTypeMapping).unwrap();
+# let mapping = elastic_types::derive::standalone_field_ser(MyTypeMapping).unwrap();
 # let json = json_str!(
 {
     "type": "object",
@@ -217,60 +217,6 @@ Automatically deriving mapping has the following limitations:
 So you can't `#[derive(ElasticType)]` on `MyType<T>`.
 - Mapping types can't be shared. This is because they need to map the type fields, so are specific to that type.
 So you can't share `MyTypeMapping` between `MyType` and `MyOtherType`.
-
-All of the above limitations can be worked around by implementing the mapping manually.
-
-Remember that Elasticsearch will automatically update mappings based on the objects it sees though,
-so if your 'un-mapped' field is serialised, then an inferred mapping will be added for it.
-
-## Manually Implement Mapping
-
-You can build object mappings by manually implementing the [`DocumentMapping`](mapping/trait.DocumentMapping.html) and [`PropertiesMapping`](mapping/trait.PropertiesMapping.html) traits:
-
-```
-# #[macro_use]
-# extern crate json_str;
-# #[macro_use]
-# extern crate serde_derive;
-# #[macro_use]
-# extern crate elastic_types_derive;
-# #[macro_use]
-# extern crate elastic_types;
-# extern crate serde;
-# use elastic_types::prelude::*;
-#[derive(Serialize)]
-pub struct MyType {
-    pub my_date: Date<DefaultDateMapping>,
-    pub my_string: String,
-    pub my_num: i32
-}
-
-//Implement DocumentType for your type. This binds it to the mapping
-impl DocumentType for MyType {
-    type Mapping = MyTypeMapping;
-}
-
-//Define the type mapping for our type
-#[derive(Default)]
-pub struct MyTypeMapping;
-impl DocumentMapping for MyTypeMapping {
-    fn name() -> &'static str { "my_type" }
-}
-impl PropertiesMapping for MyTypeMapping {
-    fn props_len() -> usize { 3 }
-
-    fn serialize_props<S>(state: &mut S) -> Result<(), S::Error>
-    where S: serde::ser::SerializeStruct {
-        try!(field_ser(state, "my_date", Date::<DefaultDateMapping>::mapping()));
-        try!(field_ser(state, "my_string", String::mapping()));
-        try!(field_ser(state, "my_num", i32::mapping()));
-
-        Ok(())
-    }
-}
-# fn main() {
-# }
-```
 
 # Links
 - [Field Types](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html)

--- a/src/types/src/geo/point/format.rs
+++ b/src/types/src/geo/point/format.rs
@@ -23,7 +23,7 @@ pub trait GeoPointFormat
     Formatting also has access to the mapping type, which could be needed to build the structure
     properly.
     */
-    fn format<S, M>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
-        where M: GeoPointMapping<Format = Self>,
+    fn format<S, TMapping>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
+        where TMapping: GeoPointMapping<Format = Self>,
               S: Serializer;
 }

--- a/src/types/src/geo/point/formats.rs
+++ b/src/types/src/geo/point/formats.rs
@@ -29,8 +29,8 @@ impl GeoPointFormat for GeoPointObject {
         Ok(Point::new(point.lon, point.lat))
     }
 
-    fn format<S, M>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
-        where M: GeoPointMapping<Format = Self>,
+    fn format<S, TMapping>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
+        where TMapping: GeoPointMapping<Format = Self>,
               S: Serializer
     {
         GeoPointObjectType {
@@ -90,8 +90,8 @@ impl GeoPointFormat for GeoPointString {
         Ok(Point::new(x, y))
     }
 
-    fn format<S, M>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
-        where M: GeoPointMapping<Format = Self>,
+    fn format<S, TMapping>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
+        where TMapping: GeoPointMapping<Format = Self>,
               S: Serializer
     {
         let mut fmtd = String::new();
@@ -135,11 +135,11 @@ impl GeoPointFormat for GeoPointHash {
         Ok(Point::new(coord.x, coord.y))
     }
 
-    fn format<S, M>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
-        where M: GeoPointMapping<Format = Self>,
+    fn format<S, TMapping>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
+        where TMapping: GeoPointMapping<Format = Self>,
               S: Serializer
     {
-        let len = match M::geohash_precision() {
+        let len = match TMapping::geohash_precision() {
             Some(Distance(l, _)) => l as usize,
             None => 12usize,
         };
@@ -192,8 +192,8 @@ impl GeoPointFormat for GeoPointArray {
         deserializer.deserialize_any(PointVisitor)
     }
 
-    fn format<S, M>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
-        where M: GeoPointMapping<Format = Self>,
+    fn format<S, TMapping>(point: &Point, serializer: S) -> Result<S::Ok, S::Error>
+        where TMapping: GeoPointMapping<Format = Self>,
               S: Serializer
     {
         [point.x(), point.y()].serialize(serializer)

--- a/src/types/src/geo/point/impls.rs
+++ b/src/types/src/geo/point/impls.rs
@@ -44,13 +44,13 @@ println!("({},{})",
 - [Elasticsearch Doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html)
 */
 #[derive(Debug, Clone, PartialEq)]
-pub struct GeoPoint<M>  where M: GeoPointMapping {
+pub struct GeoPoint<TMapping> where TMapping: GeoPointMapping {
     value: Point,
-    _m: PhantomData<M>,
+    _m: PhantomData<TMapping>,
 }
 
-impl<M> GeoPoint<M>
-    where M: GeoPointMapping
+impl<TMapping> GeoPoint<TMapping>
+    where TMapping: GeoPointMapping
 {
     /**
     Creates a new `GeoPoint` from the given coordinate.
@@ -109,53 +109,53 @@ impl<M> GeoPoint<M>
     let otherpoint: GeoPoint<DefaultGeoPointMapping<GeoPointObject>> = GeoPoint::remap(point);
     ```
     */
-    pub fn remap<MInto>(point: GeoPoint<M>) -> GeoPoint<MInto>
-        where MInto: GeoPointMapping
+    pub fn remap<TNewMapping>(point: GeoPoint<TMapping>) -> GeoPoint<TNewMapping>
+        where TNewMapping: GeoPointMapping
     {
         GeoPoint::new(point.value)
     }
 }
 
-impl<M> GeoPointFieldType<M> for GeoPoint<M>
-    where M: GeoPointMapping
+impl<TMapping> GeoPointFieldType<TMapping> for GeoPoint<TMapping>
+    where TMapping: GeoPointMapping
 {
 }
 
 impl_mapping_type!(Point, GeoPoint, GeoPointMapping);
 
-impl<M> From<Coordinate> for GeoPoint<M>
-    where M: GeoPointMapping
+impl<TMapping> From<Coordinate> for GeoPoint<TMapping>
+    where TMapping: GeoPointMapping
 {
-    fn from(point: Coordinate) -> GeoPoint<M> {
+    fn from(point: Coordinate) -> GeoPoint<TMapping> {
         GeoPoint::new(Point::new(point.x, point.y))
     }
 }
 
-impl<M> ToGeo<f64> for GeoPoint<M>
-    where M: GeoPointMapping
+impl<TMapping> ToGeo<f64> for GeoPoint<TMapping>
+    where TMapping: GeoPointMapping
 {
     fn to_geo(&self) -> Geometry {
         GeoEnum::Point(self.value.clone())
     }
 }
 
-impl<M> Serialize for GeoPoint<M>
-    where M: GeoPointMapping
+impl<TMapping> Serialize for GeoPoint<TMapping>
+    where TMapping: GeoPointMapping
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        M::Format::format::<S, M>(&self.value, serializer)
+        TMapping::Format::format::<S, TMapping>(&self.value, serializer)
     }
 }
 
-impl<'de, M> Deserialize<'de> for GeoPoint<M>
-    where M: GeoPointMapping
+impl<'de, TMapping> Deserialize<'de> for GeoPoint<TMapping>
+    where TMapping: GeoPointMapping
 {
-    fn deserialize<D>(deserializer: D) -> Result<GeoPoint<M>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<GeoPoint<TMapping>, D::Error>
         where D: Deserializer<'de>
     {
-        let point = M::Format::parse(deserializer)?;
+        let point = TMapping::Format::parse(deserializer)?;
 
         Ok(point.into())
     }

--- a/src/types/src/geo/point/mapping.rs
+++ b/src/types/src/geo/point/mapping.rs
@@ -1,29 +1,11 @@
 /*! Mapping for the Elasticsearch `geo_point` type. */
 
 use std::marker::PhantomData;
-use serde::{Serialize, Serializer};
-use serde::ser::SerializeStruct;
 use super::{GeoPointFormat, DefaultGeoPointFormat};
 use geo::mapping::Distance;
-use private::field::{DocumentField, FieldMapping, SerializeField};
-use document::FieldType;
 
 /** A field that will be mapped as a `geo_point`. */
 pub trait GeoPointFieldType<M> {}
-
-impl<T, M> FieldType<M, GeoPointFormatWrapper<M::Format>> for T
-    where T: GeoPointFieldType<M> + Serialize,
-          M: GeoPointMapping
-{
-}
-
-#[doc(hidden)]
-#[derive(Default)]
-pub struct GeoPointFormatWrapper<F>
-    where F: GeoPointFormat
-{
-    _f: PhantomData<F>,
-}
 
 /**
 The base requirements for mapping a `geo_point` type.
@@ -73,7 +55,7 @@ This will produce the following mapping:
 #     }
 # }
 # fn main() {
-# let mapping = standalone_field_ser(MyGeoPointMapping).unwrap();
+# let mapping = elastic_types::derive::standalone_field_ser(MyGeoPointMapping).unwrap();
 # let json = json_str!(
 {
     "type": "geo_point",
@@ -152,55 +134,63 @@ pub trait GeoPointMapping
     }
 }
 
-impl<T, F> FieldMapping<GeoPointFormatWrapper<F>> for T
-    where T: GeoPointMapping<Format = F>,
-          F: GeoPointFormat
-{
-    fn data_type() -> &'static str {
-        "geo_point"
-    }
-}
-
-impl<T, F> SerializeField<GeoPointFormatWrapper<F>> for T
-    where T: GeoPointMapping<Format = F>,
-          F: GeoPointFormat
-{
-    type Field = DocumentField<T, GeoPointFormatWrapper<F>>;
-}
-
-impl<T, F> Serialize for DocumentField<T, GeoPointFormatWrapper<F>>
-    where T: FieldMapping<GeoPointFormatWrapper<F>> + GeoPointMapping<Format = F>,
-          F: GeoPointFormat
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        let mut state = try!(serializer.serialize_struct("mapping", 6));
-
-        try!(state.serialize_field("type", T::data_type()));
-
-        ser_field!(state, "geohash", T::geohash());
-        ser_field!(state, "geohash_precision", T::geohash_precision());
-        ser_field!(state, "geohash_prefix", T::geohash_prefix());
-        ser_field!(state, "ignore_malformed", T::ignore_malformed());
-        ser_field!(state, "lat_lon", T::lat_lon());
-
-        state.end()
-    }
-}
-
 /** Default mapping for `geo_point`. */
 #[derive(PartialEq, Debug, Default, Clone, Copy)]
-pub struct DefaultGeoPointMapping<F = DefaultGeoPointFormat>
-    where F: GeoPointFormat
+pub struct DefaultGeoPointMapping<TFormat = DefaultGeoPointFormat>
+    where TFormat: GeoPointFormat
 {
-    _f: PhantomData<F>,
+    _f: PhantomData<TFormat>,
 }
 
-impl<F> GeoPointMapping for DefaultGeoPointMapping<F>
-    where F: GeoPointFormat
+impl<TFormat> GeoPointMapping for DefaultGeoPointMapping<TFormat>
+    where TFormat: GeoPointFormat
 {
-    type Format = F;
+    type Format = TFormat;
+}
+
+mod private {
+    use serde::{Serialize, Serializer};
+    use serde::ser::SerializeStruct;
+    use private::field::{FieldType, DocumentField, FieldMapping};
+    use super::{GeoPointFieldType, GeoPointMapping};
+
+    #[derive(Default)]
+    pub struct GeoPointPivot;
+
+    impl<TField, TMapping> FieldType<TMapping, GeoPointPivot> for TField
+        where TField: GeoPointFieldType<TMapping> + Serialize,
+              TMapping: GeoPointMapping
+    { }
+
+    impl<TMapping> FieldMapping<GeoPointPivot> for TMapping
+        where TMapping: GeoPointMapping,
+    {
+        type DocumentField = DocumentField<TMapping, GeoPointPivot>;
+
+        fn data_type() -> &'static str {
+            "geo_point"
+        }
+    }
+
+    impl<TMapping> Serialize for DocumentField<TMapping, GeoPointPivot>
+        where TMapping: FieldMapping<GeoPointPivot> + GeoPointMapping,
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: Serializer
+        {
+            let mut state = try!(serializer.serialize_struct("mapping", 6));
+
+            try!(state.serialize_field("type", TMapping::data_type()));
+
+            ser_field!(state, "geohash", TMapping::geohash());
+            ser_field!(state, "geohash_precision", TMapping::geohash_precision());
+            ser_field!(state, "geohash_prefix", TMapping::geohash_prefix());
+            ser_field!(state, "ignore_malformed", TMapping::ignore_malformed());
+            ser_field!(state, "lat_lon", TMapping::lat_lon());
+
+            state.end()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/types/src/geo/shape/impls.rs
+++ b/src/types/src/geo/shape/impls.rs
@@ -25,13 +25,13 @@ let point: GeoShape<DefaultGeoShapeMapping> = GeoShape::new(
 ```
 */
 #[derive(Debug, Clone, PartialEq)]
-pub struct GeoShape<M>  where M: GeoShapeMapping {
+pub struct GeoShape<TMapping> where TMapping: GeoShapeMapping {
     value: Geometry,
-    _m: PhantomData<M>,
+    _m: PhantomData<TMapping>,
 }
 
-impl<M> GeoShape<M>
-    where M: GeoShapeMapping
+impl<TMapping> GeoShape<TMapping>
+    where TMapping: GeoShapeMapping
 {
     /**
     Creates a new `GeoShape` from the given `Geometry`.
@@ -55,7 +55,7 @@ impl<M> GeoShape<M>
     # }
     ```
     */
-    pub fn new<I>(geo: I) -> GeoShape<M>
+    pub fn new<I>(geo: I) -> GeoShape<TMapping>
         where I: Into<Geometry>
     {
         GeoShape {
@@ -65,19 +65,19 @@ impl<M> GeoShape<M>
     }
 
     /** Change the mapping of this geo shape. */
-    pub fn remap<MInto>(shape: GeoShape<M>) -> GeoShape<MInto> 
-        where MInto: GeoShapeMapping
+    pub fn remap<TNewMapping>(shape: GeoShape<TMapping>) -> GeoShape<TNewMapping> 
+        where TNewMapping: GeoShapeMapping
     {
         GeoShape::new(shape.value)
     }
 }
 
-impl<M> GeoShapeFieldType<M> for GeoShape<M> where M: GeoShapeMapping {}
+impl<TMapping> GeoShapeFieldType<TMapping> for GeoShape<TMapping> where TMapping: GeoShapeMapping {}
 
 impl_mapping_type!(Geometry, GeoShape, GeoShapeMapping);
 
-impl<M> Serialize for GeoShape<M>
-    where M: GeoShapeMapping
+impl<TMapping> Serialize for GeoShape<TMapping>
+    where TMapping: GeoShapeMapping
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -86,15 +86,15 @@ impl<M> Serialize for GeoShape<M>
     }
 }
 
-impl<'de, M> Deserialize<'de> for GeoShape<M>
-    where M: GeoShapeMapping
+impl<'de, TMapping> Deserialize<'de> for GeoShape<TMapping>
+    where TMapping: GeoShapeMapping
 {
-    fn deserialize<D>(deserializer: D) -> Result<GeoShape<M>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<GeoShape<TMapping>, D::Error>
         where D: Deserializer<'de>
     {
         let t = try!(Geometry::deserialize(deserializer));
 
-        Ok(GeoShape::<M>::new(t))
+        Ok(GeoShape::new(t))
     }
 }
 

--- a/src/types/src/lib.rs
+++ b/src/types/src/lib.rs
@@ -82,7 +82,7 @@ wrapper:
 #     pub my_num: i32
 # }
 # fn main() {
-let mapping = serde_json::to_string(&IndexDocumentMapping::from(MyType::mapping())).unwrap();
+let mapping = serde_json::to_string(&MyType::index_mapping()).unwrap();
 # }
 ```
 
@@ -106,7 +106,7 @@ This will produce the following result:
 #     pub my_num: i32
 # }
 # fn main() {
-# let mapping = serde_json::to_string(&IndexDocumentMapping::from(MyType::mapping())).unwrap();
+# let mapping = serde_json::to_string(&MyType::index_mapping()).unwrap();
 # let json = json_str!(
 {
     "properties": {
@@ -176,7 +176,7 @@ Our mapping for `MyOtherType` then looks like:
 #     pub my_type: MyType
 # }
 # fn main() {
-# let mapping = serde_json::to_string(&IndexDocumentMapping::from(MyOtherType::mapping())).unwrap();
+# let mapping = serde_json::to_string(&MyOtherType::index_mapping()).unwrap();
 # let json = json_str!(
 {
     "properties": {
@@ -386,7 +386,7 @@ impl DateMapping for TimestampMapping {
 fn main() {
     println!("\"{}\":{{ {} }}",
         Article::name(),
-        serde_json::to_string(&IndexDocumentMapping::from(Article::mapping())).unwrap()
+        serde_json::to_string(&Article::index_mapping()).unwrap()
     );
 }
 ```
@@ -459,8 +459,6 @@ Boolean<MyMapping>
 
 The source type is `boolean` and the mapping is `MyMapping`.
 
-All Elasticsearch types implement the base `FieldType<M: FieldMapping<F>, F>` trait
-where `M` is the mapping and `F` is a type-specific format.
 All document types implement `DocumentType` with an associated `Mapping: DocumentMapping` type.
 
 The following table illustrates the types provided by `elastic_types`:
@@ -478,8 +476,8 @@ The following table illustrates the types provided by `elastic_types`:
  `text`              | `String`                    | `std`     | [`Text<M>`](string/index.html)                                                   | -
  `boolean`           | `bool`                      | `std`     | [`Boolean<M>`](boolean/index.html)                                               | -
  `ip`                | `Ipv4Addr`                  | `std`     | [`Ip<M>`](ip/index.html)                                                         | -
- `date`              | `DateTime<Utc>`             | `chrono`  | [`Date<M>`](date/index.html)                                                  | `DateFormat`
- `geo_point`         | `Point`                     | `geo`     | [`GeoPoint<M>`](geo/point/index.html)                                         | `GeoPointFormat`
+ `date`              | `DateTime<Utc>`             | `chrono`  | [`Date<M>`](date/index.html)                                                     | `DateFormat`
+ `geo_point`         | `Point`                     | `geo`     | [`GeoPoint<M>`](geo/point/index.html)                                            | `GeoPointFormat`
  `geo_shape`         | -                           | `geojson` | [`GeoShape<M>`](geo/shape/index.html)                                            | -
 
 ## Mapping

--- a/src/types/src/number/impls.rs
+++ b/src/types/src/number/impls.rs
@@ -7,14 +7,14 @@ macro_rules! number_type {
     ($wrapper_ty:ident, $mapping_ty:ident, $field_trait:ident, $std_ty:ident) => (
         /** Number type with a given mapping. */
         #[derive(Debug, Default, Clone, PartialEq)]
-        pub struct $wrapper_ty<M>  where M: $mapping_ty {
+        pub struct $wrapper_ty<TMapping>  where TMapping: $mapping_ty {
             value: $std_ty,
-            _m: PhantomData<M>
+            _m: PhantomData<TMapping>
         }
 
-        impl <M> $wrapper_ty<M> where M: $mapping_ty {
+        impl<TMapping> $wrapper_ty<TMapping> where TMapping: $mapping_ty {
             /** Creates a new number with the given mapping. */
-            pub fn new<I: Into<$std_ty>>(num: I) -> $wrapper_ty<M> {
+            pub fn new<I: Into<$std_ty>>(num: I) -> $wrapper_ty<TMapping> {
                 $wrapper_ty {
                     value: num.into(),
                     _m: PhantomData
@@ -22,19 +22,19 @@ macro_rules! number_type {
             }
 
             /** Change the mapping of this number. */
-            pub fn remap<MInto>(number: $wrapper_ty<M>) -> $wrapper_ty<MInto> 
-                where MInto: $mapping_ty
+            pub fn remap<TNewMapping>(number: $wrapper_ty<TMapping>) -> $wrapper_ty<TNewMapping> 
+                where TNewMapping: $mapping_ty
             {
                 $wrapper_ty::new(number.value)
             }
         }
 
-        impl <M> $field_trait<M> for $wrapper_ty<M> where M: $mapping_ty { }
+        impl<TMapping> $field_trait<TMapping> for $wrapper_ty<TMapping> where TMapping: $mapping_ty { }
 
         impl_mapping_type!($std_ty, $wrapper_ty, $mapping_ty);
 
         //Serialize elastic number.
-        impl <M> Serialize for $wrapper_ty<M> where M: $mapping_ty {
+        impl<TMapping> Serialize for $wrapper_ty<TMapping> where TMapping: $mapping_ty {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where
             S: Serializer {
                 self.value.serialize(serializer)
@@ -42,12 +42,12 @@ macro_rules! number_type {
         }
 
         //Deserialize elastic number.
-        impl <'de, M: $mapping_ty> Deserialize<'de> for $wrapper_ty<M> {
-            fn deserialize<D>(deserializer: D) -> Result<$wrapper_ty<M>, D::Error> where
+        impl <'de, TMapping> Deserialize<'de> for $wrapper_ty<TMapping> where TMapping: $mapping_ty {
+            fn deserialize<D>(deserializer: D) -> Result<$wrapper_ty<TMapping>, D::Error> where
             D: Deserializer<'de> {
                 let t = try!($std_ty::deserialize(deserializer));
 
-                Ok($wrapper_ty::<M>::new(t))
+                Ok($wrapper_ty::new(t))
             }
         }
     )

--- a/src/types/src/private/field.rs
+++ b/src/types/src/private/field.rs
@@ -1,48 +1,67 @@
+/*!
+Implementation boilerplate for mappable fields.
+
+Most of these types have a generic `TPivot` parameter.
+The idea is to use a concrete type for `TPivot` so non-overlapping blanket implementations can be added for `TMapping`.
+*/
+
 use std::marker::PhantomData;
 use std::borrow::Borrow;
 use std::ops::Deref;
 use serde::Serialize;
 
-pub trait SerializeField<F> {
-    type Field: Serialize + Default;
+/** The base representation of an Elasticsearch data type. */
+pub trait FieldType<TMapping, TPivot>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default
+{
+    /** Get a serialisable instance of the type mapping as a field. */
+    fn field_mapping() -> TMapping {
+        TMapping::default()
+    }
 }
 
-pub trait FieldMapping<F>
-    where Self: Default + SerializeField<F>,
-          F: Default
+/** The base representation of an Elasticsearch data type mapping. */
+pub trait FieldMapping<TPivot>
+    where Self: Default,
+          TPivot: Default
 {
+    /** Prevents infinite recursion when resolving `Serialize` on nested mappings. */
+    type DocumentField: Serialize + Default;
+
     fn data_type() -> &'static str {
         "object"
     }
 }
 
 /** Captures traits required for conversion between a field with mapping and a default counterpart. */
-pub trait StdField<T>
-    where Self: PartialEq<T> + Deref<Target = T> + Borrow<T>,
-          T: PartialEq<Self>
+pub trait StdField<TStd>
+    where Self: PartialEq<TStd> + Deref<Target = TStd> + Borrow<TStd>,
+          TStd: PartialEq<Self>
 {
 }
+
+// TODO: Rename `DocumentField` to `SerializeFieldMapping`
 
 /**
-A wrapper type used to work around conflicting implementations of `Serialize`
-for the various mapping traits.
+A wrapper type used to work around conflicting implementations of `Serialize` for the various mapping traits.
 
-Serialising `Field` will produce the mapping for the given type,
-suitable as the mapping of a field for a document.
+Serialising `DocumentField` will produce the mapping for the given type, suitable as the mapping of a field for a document.
+Individual implementations of `Serialize` for `DocumentField` are spread throughout other modules.
 */
 #[derive(Default)]
-pub struct DocumentField<M, F>
-    where M: FieldMapping<F>,
-          F: Default
+pub struct DocumentField<TMapping, TPivot>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default
 {
-    _m: PhantomData<(M, F)>,
+    _m: PhantomData<(TMapping, TPivot)>,
 }
 
-impl<M, F> From<M> for DocumentField<M, F>
-    where M: FieldMapping<F>,
-          F: Default
+impl<TMapping, TPivot> From<TMapping> for DocumentField<TMapping, TPivot>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default
 {
-    fn from(_: M) -> Self {
-        DocumentField::<M, F>::default()
+    fn from(_: TMapping) -> Self {
+        DocumentField::<TMapping, TPivot>::default()
     }
 }

--- a/src/types/src/private/impls.rs
+++ b/src/types/src/private/impls.rs
@@ -4,16 +4,16 @@ use std::collections::{HashMap, BTreeMap};
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
 
-use super::field::{DocumentField, FieldMapping, SerializeField};
-use document::FieldType;
+use super::field::{DocumentField, FieldType, FieldMapping};
+
+pub trait DefaultFieldType {}
 
 /** A mapping implementation for a non-core type, or anywhere it's ok for Elasticsearch to infer the mapping at index-time. */
 #[derive(Debug, PartialEq, Default, Clone)]
 struct DefaultMapping;
-impl FieldMapping<()> for DefaultMapping {}
-
-impl SerializeField<()> for DefaultMapping {
-    type Field = DocumentField<Self, ()>;
+impl FieldMapping<()> for DefaultMapping
+{
+    type DocumentField = DocumentField<DefaultMapping, ()>;
 }
 
 impl Serialize for DocumentField<DefaultMapping, ()> {
@@ -28,6 +28,8 @@ impl Serialize for DocumentField<DefaultMapping, ()> {
     }
 }
 
+pub trait WrappedFieldType<TMapping, TPivot> {}
+
 /**
 Mapping for a wrapped value, like an array or optional type.
 
@@ -35,66 +37,65 @@ In Elasticsearch, arrays and optional types aren't special, anything can be inde
 So the mapping for an array or optional type is just the mapping for the type it contains.
 */
 #[derive(Debug, Default, Clone)]
-pub struct WrappedMapping<M, F>
-    where M: FieldMapping<F>,
-          F: Default
+pub struct WrappedMapping<TMapping, TPivot>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default
 {
-    _m: PhantomData<(M, F)>,
+    _m: PhantomData<(TMapping, TPivot)>,
 }
 
-impl<M, F> FieldMapping<F> for WrappedMapping<M, F>
-    where M: FieldMapping<F>,
-          F: Default
+impl<TMapping, TPivot> FieldMapping<TPivot> for WrappedMapping<TMapping, TPivot>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default
 {
+    type DocumentField = TMapping::DocumentField;
+
     fn data_type() -> &'static str {
-        M::data_type()
+        TMapping::data_type()
     }
 }
 
-impl<M, F> SerializeField<F> for WrappedMapping<M, F>
-    where M: FieldMapping<F>,
-          F: Default
-{
-    type Field = M::Field;
-}
-
-impl<M, F> Serialize for DocumentField<WrappedMapping<M, F>, F>
-    where M: FieldMapping<F>,
-          F: Default
+impl<TMapping, TPivot> Serialize for DocumentField<WrappedMapping<TMapping, TPivot>, TPivot>
+    where TMapping: FieldMapping<TPivot>,
+          TPivot: Default,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        M::Field::default().serialize(serializer)
+        TMapping::DocumentField::default().serialize(serializer)
     }
 }
 
+impl<TField> FieldType<DefaultMapping, ()> for TField
+    where TField: DefaultFieldType
+{ }
+
 /** Mapping implementation for a standard binary tree map. */
-impl<K, V> FieldType<DefaultMapping, ()> for BTreeMap<K, V>
+impl<K, V> DefaultFieldType for BTreeMap<K, V>
     where K: AsRef<str> + Ord + Serialize,
           V: Serialize
-{
-}
+{ }
 
 /** Mapping implementation for a standard hash map. */
-impl<K, V> FieldType<DefaultMapping, ()> for HashMap<K, V>
+impl<K, V> DefaultFieldType for HashMap<K, V>
     where K: AsRef<str> + Eq + Hash + Serialize,
           V: Serialize
-{
-}
+{ }
 
-impl<T, M, F> FieldType<WrappedMapping<M, F>, F> for Vec<T>
-    where T: FieldType<M, F>,
-          M: FieldMapping<F>,
-          F: Default,
-          DocumentField<M, F>: Serialize
-{
-}
+impl<TField, TMapping, TPivot> FieldType<WrappedMapping<TMapping, TPivot>, TPivot> for TField
+    where TField: WrappedFieldType<TMapping, TPivot>,
+          TMapping: FieldMapping<TPivot>,
+          TPivot: Default,
+{ }
 
-impl<T, M, F> FieldType<WrappedMapping<M, F>, F> for Option<T>
-    where T: FieldType<M, F>,
-          M: FieldMapping<F>,
-          F: Default,
-          DocumentField<M, F>: Serialize
-{
-}
+impl<TField, TMapping, TPivot> WrappedFieldType<TMapping, TPivot> for Vec<TField>
+    where TField: FieldType<TMapping, TPivot>,
+          TMapping: FieldMapping<TPivot>,
+          TPivot: Default,
+{ }
+
+impl<TField, TMapping, TPivot> WrappedFieldType<TMapping, TPivot> for Option<TField>
+    where TField: FieldType<TMapping, TPivot>,
+          TMapping: FieldMapping<TPivot>,
+          TPivot: Default,
+{ }

--- a/src/types/src/private/mod.rs
+++ b/src/types/src/private/mod.rs
@@ -1,3 +1,9 @@
+/*!
+Implementation details for field mapping.
+
+This module contains implementation details that support serialisation of mappable fields.
+*/
+
 #[macro_use]
 pub mod macros;
 pub mod field;

--- a/src/types/src/string/keyword/impls.rs
+++ b/src/types/src/string/keyword/impls.rs
@@ -21,13 +21,13 @@ let string = Keyword::<DefaultKeywordMapping>::new("my string value");
 ```
 */
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct Keyword<M>  where M: KeywordMapping {
+pub struct Keyword<TMapping>  where TMapping: KeywordMapping {
     value: String,
-    _m: PhantomData<M>,
+    _m: PhantomData<TMapping>,
 }
 
-impl<M> Keyword<M>
-    where M: KeywordMapping
+impl<TMapping> Keyword<TMapping>
+    where TMapping: KeywordMapping
 {
     /**
     Creates a new `Keyword` with the given mapping.
@@ -43,7 +43,7 @@ impl<M> Keyword<M>
     let string = Keyword::<DefaultKeywordMapping>::new("my string");
     ```
     */
-    pub fn new<I>(string: I) -> Keyword<M>
+    pub fn new<I>(string: I) -> Keyword<TMapping>
         where I: Into<String>
     {
         Keyword {
@@ -53,10 +53,10 @@ impl<M> Keyword<M>
     }
 
     /** Change the mapping of this string. */
-    pub fn remap<MInto>(self) -> Keyword<MInto>
-        where MInto: KeywordMapping
+    pub fn remap<TNewMapping>(keyword: Keyword<TMapping>) -> Keyword<TNewMapping>
+        where TNewMapping: KeywordMapping
     {
-        Keyword::<MInto>::new(self.value)
+        Keyword::new(keyword.value)
     }
 }
 

--- a/src/types/src/string/keyword/mapping.rs
+++ b/src/types/src/string/keyword/mapping.rs
@@ -4,21 +4,10 @@ use std::collections::BTreeMap;
 use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
 use string::mapping::{StringField, IndexOptions};
-use private::field::{DocumentField, FieldMapping, SerializeField};
-use document::FieldType;
+use private::field::FieldMapping;
 
 /** A field that will be mapped as a `keyword`. */
-pub trait KeywordFieldType<M> {}
-
-impl<T, M> FieldType<M, KeywordFormat> for T
-    where M: KeywordMapping,
-          T: KeywordFieldType<M> + Serialize
-{
-}
-
-#[doc(hidden)]
-#[derive(Default)]
-pub struct KeywordFormat;
+pub trait KeywordFieldType<TMapping> {}
 
 /**
 The base requirements for mapping a `string` type.
@@ -224,49 +213,6 @@ pub trait KeywordMapping
     }
 }
 
-impl<T> FieldMapping<KeywordFormat> for T
-    where T: KeywordMapping
-{
-    fn data_type() -> &'static str {
-        "keyword"
-    }
-}
-
-impl<T> SerializeField<KeywordFormat> for T
-    where T: KeywordMapping
-{
-    type Field = DocumentField<T, KeywordFormat>;
-}
-
-impl<T> Serialize for DocumentField<T, KeywordFormat>
-    where T: FieldMapping<KeywordFormat> + KeywordMapping
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        let mut state = try!(serializer.serialize_struct("mapping", 15));
-
-        try!(state.serialize_field("type", T::data_type()));
-
-        ser_field!(state, "boost", T::boost());
-        ser_field!(state, "analyzer", T::analyzer());
-        ser_field!(state, "doc_values", T::doc_values());
-        ser_field!(state, "eager_global_ordinals", T::eager_global_ordinals());
-        ser_field!(state, "fields", T::fields());
-        ser_field!(state, "include_in_all", T::include_in_all());
-        ser_field!(state, "ignore_above", T::ignore_above());
-        ser_field!(state, "index", T::index());
-        ser_field!(state, "index_options", T::index_options());
-        ser_field!(state, "norms", T::norms());
-        ser_field!(state, "null_value", T::null_value());
-        ser_field!(state, "store", T::store());
-        ser_field!(state, "search_analyzer", T::search_analyzer());
-        ser_field!(state, "similarity", T::similarity());
-
-        state.end()
-    }
-}
-
 /** Default mapping for `bool`. */
 #[derive(PartialEq, Debug, Default, Clone, Copy)]
 pub struct DefaultKeywordMapping;
@@ -349,5 +295,59 @@ impl Serialize for KeywordFieldMapping {
         ser_field!(state, "similarity", self.similarity);
 
         state.end()
+    }
+}
+
+mod private {
+    use serde::{Serialize, Serializer};
+    use serde::ser::SerializeStruct;
+    use private::field::{FieldType, DocumentField, FieldMapping};
+    use super::{KeywordFieldType, KeywordMapping};
+
+    #[derive(Default)]
+    pub struct KeywordPivot;
+
+    impl<TField, TMapping> FieldType<TMapping, KeywordPivot> for TField
+        where TField: KeywordFieldType<TMapping> + Serialize,
+              TMapping: KeywordMapping
+    { }
+
+    impl<TMapping> FieldMapping<KeywordPivot> for TMapping
+        where TMapping: KeywordMapping
+    {
+        type DocumentField = DocumentField<TMapping, KeywordPivot>;
+
+        fn data_type() -> &'static str {
+            "keyword"
+        }
+    }
+
+    impl<TMapping> Serialize for DocumentField<TMapping, KeywordPivot>
+        where TMapping: FieldMapping<KeywordPivot> + KeywordMapping
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where S: Serializer
+        {
+            let mut state = try!(serializer.serialize_struct("mapping", 15));
+
+            try!(state.serialize_field("type", TMapping::data_type()));
+
+            ser_field!(state, "boost", TMapping::boost());
+            ser_field!(state, "analyzer", TMapping::analyzer());
+            ser_field!(state, "doc_values", TMapping::doc_values());
+            ser_field!(state, "eager_global_ordinals", TMapping::eager_global_ordinals());
+            ser_field!(state, "fields", TMapping::fields());
+            ser_field!(state, "include_in_all", TMapping::include_in_all());
+            ser_field!(state, "ignore_above", TMapping::ignore_above());
+            ser_field!(state, "index", TMapping::index());
+            ser_field!(state, "index_options", TMapping::index_options());
+            ser_field!(state, "norms", TMapping::norms());
+            ser_field!(state, "null_value", TMapping::null_value());
+            ser_field!(state, "store", TMapping::store());
+            ser_field!(state, "search_analyzer", TMapping::search_analyzer());
+            ser_field!(state, "similarity", TMapping::similarity());
+
+            state.end()
+        }
     }
 }

--- a/src/types/src/string/macros.rs
+++ b/src/types/src/string/macros.rs
@@ -1,19 +1,19 @@
 macro_rules! impl_string_type {
     ($wrapper_ty:ident, $mapping_ty:ident, $field_type:ident) => (
-        impl <M> $field_type<M> for $wrapper_ty<M> where
-        M: $mapping_ty { }
+        impl<TMapping> $field_type<TMapping> for $wrapper_ty<TMapping> where
+        TMapping: $mapping_ty { }
 
         impl_mapping_type!(String, $wrapper_ty, $mapping_ty);
 
-        impl <M> AsRef<str> for $wrapper_ty<M> where
-        M: $mapping_ty {
+        impl<TMapping> AsRef<str> for $wrapper_ty<TMapping> where
+        TMapping: $mapping_ty {
             fn as_ref(&self) -> &str {
                 &self.value
             }
         }
 
-        impl<'a, M> PartialEq<&'a str> for $wrapper_ty<M> where
-        M: $mapping_ty {
+        impl<'a, TMapping> PartialEq<&'a str> for $wrapper_ty<TMapping> where
+        TMapping: $mapping_ty {
             fn eq(&self, other: & &'a str) -> bool {
                 PartialEq::eq(&self.value, *other)
             }
@@ -23,51 +23,50 @@ macro_rules! impl_string_type {
             }
         }
 
-        impl<'a, M> PartialEq<$wrapper_ty<M>> for &'a str where
-        M: $mapping_ty {
-            fn eq(&self, other: &$wrapper_ty<M>) -> bool {
+        impl<'a, TMapping> PartialEq<$wrapper_ty<TMapping>> for &'a str where
+        TMapping: $mapping_ty {
+            fn eq(&self, other: &$wrapper_ty<TMapping>) -> bool {
                 PartialEq::eq(*self, &other.value)
             }
 
-            fn ne(&self, other: &$wrapper_ty<M>) -> bool {
+            fn ne(&self, other: &$wrapper_ty<TMapping>) -> bool {
                 PartialEq::ne(*self, &other.value)
             }
         }
 
-        impl <M> Serialize for $wrapper_ty<M> where
-        M: $mapping_ty {
+        impl<TMapping> Serialize for $wrapper_ty<TMapping> where
+        TMapping: $mapping_ty {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where
             S: Serializer {
                 serializer.serialize_str(&self.value)
             }
         }
 
-        impl <'de, M> Deserialize<'de> for $wrapper_ty<M> where
-        M: $mapping_ty {
-            fn deserialize<D>(deserializer: D) -> Result<$wrapper_ty<M>, D::Error> where
+        impl<'de, TMapping> Deserialize<'de> for $wrapper_ty<TMapping> where
+        TMapping: $mapping_ty {
+            fn deserialize<D>(deserializer: D) -> Result<$wrapper_ty<TMapping>, D::Error> where
             D: Deserializer<'de> {
                 #[derive(Default)]
-                struct StringVisitor<M> where
-                M: $mapping_ty {
-                    _m: PhantomData<M>
+                struct StringVisitor<TMapping> {
+                    _m: PhantomData<TMapping>
                 }
 
-                impl <'de, M> Visitor<'de> for StringVisitor<M> where
-                M: $mapping_ty {
-                    type Value = $wrapper_ty<M>;
+                impl<'de, TMapping> Visitor<'de> for StringVisitor<TMapping> where
+                TMapping: $mapping_ty {
+                    type Value = $wrapper_ty<TMapping>;
 
                     fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result 
                     {
                         write!(formatter, "a json string")
                     }
 
-                    fn visit_str<E>(self, v: &str) -> Result<$wrapper_ty<M>, E> where
+                    fn visit_str<E>(self, v: &str) -> Result<$wrapper_ty<TMapping>, E> where
                     E: Error {
-                        Ok($wrapper_ty::<M>::new(v))
+                        Ok($wrapper_ty::new(v))
                     }
                 }
 
-                deserializer.deserialize_any(StringVisitor::<M>::default())
+                deserializer.deserialize_any(StringVisitor::default())
             }
         }
     );

--- a/src/types/src/string/mapping.rs
+++ b/src/types/src/string/mapping.rs
@@ -244,7 +244,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use prelude::*;
-    use private::field::DocumentField;
+    use private::field::{FieldType, DocumentField};
 
     #[derive(Default, Clone)]
     pub struct MyTextMapping;
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn string_has_default_mapping() {
-        assert_eq!(DefaultStringMapping, String::mapping());
+        assert_eq!(DefaultStringMapping, String::field_mapping());
     }
 
     #[test]

--- a/src/types/src/string/mod.rs
+++ b/src/types/src/string/mod.rs
@@ -126,7 +126,7 @@ mod tests {
 
         let string: Keyword<DefaultKeywordMapping> = Keyword::new("stuff");
 
-        assert!(takes_custom_mapping(string.remap()));
+        assert!(takes_custom_mapping(Keyword::remap(string)));
     }
 
     #[test]
@@ -153,7 +153,7 @@ mod tests {
 
         let string: Text<DefaultTextMapping> = Text::new("stuff");
 
-        assert!(takes_custom_mapping(string.remap()));
+        assert!(takes_custom_mapping(Text::remap(string)));
     }
 
     #[test]

--- a/src/types/src/string/text/impls.rs
+++ b/src/types/src/string/text/impls.rs
@@ -25,13 +25,13 @@ let string = Text::<DefaultTextMapping>::new("my string value");
 ```
 */
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct Text<M>  where M: TextMapping {
+pub struct Text<TMapping> where TMapping: TextMapping {
     value: String,
-    _m: PhantomData<M>,
+    _m: PhantomData<TMapping>,
 }
 
-impl<M> Text<M>
-    where M: TextMapping
+impl<TMapping> Text<TMapping>
+    where TMapping: TextMapping
 {
     /**
     Creates a new `Text` with the given mapping.
@@ -47,7 +47,7 @@ impl<M> Text<M>
     let string = Text::<DefaultTextMapping>::new("my string");
     ```
     */
-    pub fn new<I>(string: I) -> Text<M>
+    pub fn new<I>(string: I) -> Text<TMapping>
         where I: Into<String>
     {
         Text {
@@ -57,10 +57,10 @@ impl<M> Text<M>
     }
 
     /** Change the mapping of this string. */
-    pub fn remap<MInto>(self) -> Text<MInto>
-        where MInto: TextMapping
+    pub fn remap<TNewMapping>(text: Text<TMapping>) -> Text<TNewMapping>
+        where TNewMapping: TextMapping
     {
-        Text::<MInto>::new(self.value)
+        Text::new(text.value)
     }
 }
 


### PR DESCRIPTION
This is a fairly noisy PR. The gist of it is:

- Use more descriptive names for generic types than `M` or `F` in `elastic_types`. We now use things like `TField`, `TMapping`, `TPivot`. The `TPivot` generic has made it pretty clear where we're leaking the internal types that make serialisation work
- Refactor some of the field types so we don't leak them publicly. The entry point to working with mappings is through documents, so we don't have public methods to play with field mappings directly anymore. This makes it difficult for a user to implement document mapping manually, but the manual implementation has never been very useful and existed while custom derive wasn't stable

In the typical case, this means getting the mapping for a document is more ergonomic. You can call something like `Account::index_mapping()` instead of having to do `IndexDocumentMapping::from(Account::mapping())`.