### PR TITLE
Accept HttpClient or Handle when building async client

### DIFF
--- a/examples/account_sample/src/model/index.rs
+++ b/examples/account_sample/src/model/index.rs
@@ -7,7 +7,7 @@
 use serde_json::Value;
 use elastic::client::requests::Index;
 use elastic::types::prelude::DocumentType;
-use super::account::{self, Account};
+use super::account::Account;
 
 /// Get the name of the bank index.
 pub fn name() -> Index<'static> {

--- a/src/elastic/src/client/async.rs
+++ b/src/elastic/src/client/async.rs
@@ -327,13 +327,16 @@ impl AsyncClientBuilder {
     Build with a given `AsyncHttpClient`.
 
     ```no_run
+    # extern crate tokio_core;
     # extern crate reqwest;
     # extern crate elastic;
+    # use tokio_core::reactor::Core;
+    # use reqwest::unstable::async::Client;
     # use elastic::prelude::*;
     # fn main() { run().unwrap() }
     # fn run() -> Result<(), Box<::std::error::Error>> {
     let mut core = Core::new()?;
-    let client = reqwest::unstable::Client::new(&core.handle());
+    let client = Client::new(&core.handle());
 
     let builder = AsyncClientBuilder::new().build(client);
     # Ok(())

--- a/src/elastic/src/client/sync.rs
+++ b/src/elastic/src/client/sync.rs
@@ -158,7 +158,9 @@ impl SyncClientBuilder {
     ```
     # use elastic::prelude::*;
     let builder = SyncClientBuilder::new()
-        .params(|p| p.url_param("pretty", true));
+        .params(|p| {
+            p.url_param("pretty", true)
+        });
     ```
 
     Add an authorization header:
@@ -168,7 +170,9 @@ impl SyncClientBuilder {
     use elastic::http::header::Authorization;
 
     let builder = SyncClientBuilder::new()
-        .params(|p| p.header(Authorization("let me in".to_owned())));
+        .params(|p| {
+            p.header(Authorization("let me in".to_owned()))
+        });
     ```
 
     Specify a base url (prefer the [`base_url`][SyncClientBuilder.base_url] method on `SyncClientBuilder` instead):
@@ -176,7 +180,9 @@ impl SyncClientBuilder {
     ```
     # use elastic::prelude::*;
     let builder = SyncClientBuilder::new()
-        .params(|p| p.base_url("https://my_es_cluster/some_path"));
+        .params(|p| {
+            p.base_url("https://my_es_cluster/some_path")
+        });
     ```
 
     [SyncClientBuilder.base_url]: #method.base_url


### PR DESCRIPTION
Closes #239 

Adds a trait that can be used to construct an underlying `reqwest` client in the async builder. This avoids the ambiguity of supplying a `reqwest` client and then having to also supply a redundant `Handle` when building. 