### PR TITLE
Remove explicit logging from responses

### DIFF
--- a/src/responses/Cargo.toml
+++ b/src/responses/Cargo.toml
@@ -9,13 +9,9 @@ repository = "https://github.com/elastic-rs/elastic"
 readme = "README.md"
 
 [dependencies]
-log = "~0.3"
 serde = "~1"
 serde_derive = "~1"
 serde_json = "~1"
-slog = "~1.4"
-slog-envlogger = "~0.5"
-slog-stdlog = "~1.1"
 quick-error = "~1.1"
 
 [dev-dependencies]

--- a/src/responses/src/lib.rs
+++ b/src/responses/src/lib.rs
@@ -126,8 +126,6 @@ in a `GetResponse`.
 */
 
 #[deny(warnings, missing_docs)]
-#[macro_use]
-extern crate log;
 
 #[macro_use]
 extern crate serde_derive;
@@ -137,9 +135,6 @@ extern crate quick_error;
 
 extern crate serde;
 extern crate serde_json;
-
-extern crate slog_envlogger;
-extern crate slog_stdlog;
 
 pub mod error;
 pub mod parsing;

--- a/src/responses/src/search.rs
+++ b/src/responses/src/search.rs
@@ -316,7 +316,6 @@ type RowData<'a> = BTreeMap<Cow<'a, str>, &'a Value>;
 fn insert_value<'a>(fieldname: &str, json_object: &'a Object, keyname: &str, rowdata: &mut RowData<'a>) {
     if let Some(v) = json_object.get(fieldname) {
         let field_name = format!("{}_{}", keyname, fieldname);
-        debug!("ITER: Insert value! {} {:?}", field_name, v);
         rowdata.insert(Cow::Owned(field_name), v);
     }
 }
@@ -339,12 +338,9 @@ impl<'a> Iterator for Aggs<'a> {
                 // Save
                 self.iter_stack.push((active_name, array));
 
-                debug!("ITER: Depth {}", self.iter_stack.len());
                 // FIXME: Move this, to be able to process first line too
                 if let Some(n) = n {
                     if let Some(ref mut row) = self.current_row {
-                        debug!("ITER: Row: {:?}", row);
-
                         for (key, value) in n.as_object().expect("Shouldn't get here!") {
                             if let Some(c) = value.as_object() {
                                 // Child Aggregation
@@ -357,7 +353,6 @@ impl<'a> Iterator for Aggs<'a> {
                                 }
                                 // Simple Value Aggregation Name
                                 if let Some(v) = c.get("value") {
-                                    debug!("ITER: Insert value! {} {:?}", key, v);
                                     row.insert(Cow::Borrowed(key), v);
                                     continue;
                                 }
@@ -377,14 +372,6 @@ impl<'a> Iterator for Aggs<'a> {
                                         let l = child_values.get("lower");
                                         let un = format!("{}_std_deviation_bounds_upper", key);
                                         let ln = format!("{}_std_deviation_bounds_lower", key);
-                                        debug!(
-                                            "ITER: Insert std_dev_bounds! {} {} u: {:?} l: \
-                                             {:?}",
-                                            un,
-                                            ln,
-                                            u.unwrap(),
-                                            l.unwrap()
-                                        );
                                         row.insert(Cow::Owned(un), u.unwrap());
                                         row.insert(Cow::Owned(ln), l.unwrap());
                                     }
@@ -393,11 +380,9 @@ impl<'a> Iterator for Aggs<'a> {
 
                             if key == "key" {
                                 // Bucket Aggregation Name
-                                debug!("ITER: Insert bucket! {} {:?}", active_name, value);
                                 row.insert(Cow::Borrowed(active_name), value);
                             } else if key == "doc_count" {
                                 // Bucket Aggregation Count
-                                debug!("ITER: Insert bucket count! {} {:?}", active_name, value);
                                 let field_name = format!("{}_doc_count", active_name);
                                 row.insert(Cow::Owned(field_name), value);
                             }
@@ -405,19 +390,14 @@ impl<'a> Iterator for Aggs<'a> {
                     }
                 } else {
                     // Was nothing here, exit
-                    debug!("ITER: Exit!");
                     self.iter_stack.pop();
                     continue;
                 }
 
                 if !has_buckets {
-                    debug!("ITER: Bucketless!");
                     break;
-                } else {
-                    debug!("ITER: Dive!");
                 }
             } else {
-                debug!("ITER: Done!");
                 self.current_row = None;
                 break;
             };


### PR DESCRIPTION
It doesn't really need to be there anymore and means we don't need a dependency on `slog`, which was breaking the build in `nightly`.