### PR TITLE
Consistent Builders

### DIFF
--- a/benches/elastic/src/main.rs
+++ b/benches/elastic/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
     let runs = measure::parse_runs_from_env();
 
     let client = SyncClientBuilder::new()
-        .params(|p| p.header(http::header::Connection::keep_alive()))
+        .params_fluent(|p| p.header(http::header::Connection::keep_alive()))
         .build()
         .unwrap();
 

--- a/benches/elastic_async/src/main.rs
+++ b/benches/elastic_async/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     let runs = measure::parse_runs_from_env();
 
     let client = AsyncClientBuilder::new()
-        .params(|p| p.header(http::header::Connection::keep_alive()))
+        .params_fluent(|p| p.header(http::header::Connection::keep_alive()))
         .build(&core.handle())
         .unwrap();
 

--- a/benches/elastic_bulk/src/main.rs
+++ b/benches/elastic_bulk/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
 
     let client = SyncClientBuilder::new()
         .http_client(http_client())
-        .params(|p| p.header(http::header::Connection::keep_alive()))
+        .params_fluent(|p| p.header(http::header::Connection::keep_alive()))
         .build()
         .unwrap();
 

--- a/benches/elastic_raw/src/main.rs
+++ b/benches/elastic_raw/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     let runs = measure::parse_runs_from_env();
 
     let client = SyncClientBuilder::new()
-        .params(|p| p.header(http::header::Connection::keep_alive()))
+        .params_fluent(|p| p.header(http::header::Connection::keep_alive()))
         .build()
         .unwrap();
 

--- a/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -24,7 +24,7 @@ impl PutBulkAccounts for Client {
 
         let res = self.io
             .request(req)
-            .params(|params| params.url_param("refresh", true))
+            .params_fluent(|params| params.url_param("refresh", true))
             .send()?
             .into_response::<BulkErrorsResponse>()?;
 

--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "~0.8.0", features = ["unstable"] }
 futures = "~0.1.16"
 tokio-core = "~0.1.9"
 futures-cpupool = "~0.1.6"
+fluent_builder = { version = "*", git = "https://github.com/KodrAus/fluent_builder.git", branch = "feat/fnonce-builders" }
 
 elastic_requests = { version = "~0.20.2", path = "../requests" }
 elastic_responses = { version = "~0.20.2", path = "../responses" }

--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { version = "~0.8.0", features = ["unstable"] }
 futures = "~0.1.16"
 tokio-core = "~0.1.9"
 futures-cpupool = "~0.1.6"
-fluent_builder = { version = "*", git = "https://github.com/KodrAus/fluent_builder.git", branch = "feat/fnonce-builders" }
+fluent_builder = "~0.5"
 
 elastic_requests = { version = "~0.20.2", path = "../requests" }
 elastic_responses = { version = "~0.20.2", path = "../responses" }

--- a/src/elastic/examples/custom_response.rs
+++ b/src/elastic/examples/custom_response.rs
@@ -59,7 +59,7 @@ fn run() -> Result<(), Box<Error>> {
     // Send the request and process the response.
     let res = client
         .request(SearchRequest::new(query.to_string()))
-        .params(|q| q.url_param("filter_path", "hits.hits._source"))
+        .params_fluent(|q| q.url_param("filter_path", "hits.hits._source"))
         .send()?
         .into_response::<SearchResponse>()?;
 

--- a/src/elastic/examples/load_balanced_async.rs
+++ b/src/elastic/examples/load_balanced_async.rs
@@ -7,14 +7,11 @@
 extern crate elastic;
 extern crate env_logger;
 extern crate futures;
-#[macro_use]
-extern crate serde_json;
 extern crate tokio_core;
 
 use std::error::Error;
 use futures::Future;
 use tokio_core::reactor::Core;
-use serde_json::Value;
 use elastic::prelude::*;
 
 fn run() -> Result<(), Box<Error>> {

--- a/src/elastic/examples/raw.rs
+++ b/src/elastic/examples/raw.rs
@@ -16,7 +16,7 @@ fn run() -> Result<(), Box<Error>> {
     // A reqwest HTTP client and default parameters.
     // The `params` includes the base node url (http://localhost:9200).
     let client = SyncClientBuilder::new()
-        .params(|p| p.url_param("pretty", true))
+        .params_fluent(|p| p.url_param("pretty", true))
         .build()?;
 
     // A search request from the body.

--- a/src/elastic/examples/typed.rs
+++ b/src/elastic/examples/typed.rs
@@ -100,7 +100,7 @@ fn put_index(client: &SyncClient) -> Result<(), Error> {
 fn put_doc(client: &SyncClient, doc: MyType) -> Result<(), Error> {
     client
         .document_index(sample_index(), id(doc.id), doc)
-        .params(|p| p.url_param("refresh", true))
+        .params_fluent(|p| p.url_param("refresh", true))
         .send()?;
 
     Ok(())

--- a/src/elastic/examples/typed_async.rs
+++ b/src/elastic/examples/typed_async.rs
@@ -119,7 +119,7 @@ fn put_index(client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
 fn put_doc(client: AsyncClient, doc: MyType) -> Box<Future<Item = (), Error = Error>> {
     let index_doc = client
         .document_index(sample_index(), id(doc.id), doc)
-        .params(|p| p.url_param("refresh", true))
+        .params_fluent(|p| p.url_param("refresh", true))
         .send()
         .map(|_| ());
 

--- a/src/elastic/examples/update.rs
+++ b/src/elastic/examples/update.rs
@@ -50,7 +50,7 @@ fn run() -> Result<(), Box<Error>> {
     // Index the document
     client
         .document_index(sample_index(), id(doc_id), doc)
-        .params(|p| p.url_param("refresh", true))
+        .params_fluent(|p| p.url_param("refresh", true))
         .send()?;
 
     // Update the document using a script

--- a/src/elastic/src/client/mod.rs
+++ b/src/elastic/src/client/mod.rs
@@ -272,7 +272,7 @@ If the request was sent asynchronously, the response is returned as a `Future`.
 let request_builder = client.request(req);
 
 // Set additional url parameters
-let request_builder = request_builder.params(|p| p
+let request_builder = request_builder.params_fluent(|p| p
     .url_param("pretty", true)
     .url_param("refresh", true)
 );

--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -95,9 +95,8 @@ where
     {
         let ty = TDocument::name().into();
 
-        RequestBuilder::new(
+        RequestBuilder::initial(
             self.clone(),
-            None,
             DeleteRequestInner {
                 index: index,
                 ty: ty,

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -121,9 +121,8 @@ where
     {
         let ty = TDocument::name().into();
 
-        RequestBuilder::new(
+        RequestBuilder::initial(
             self.clone(),
-            None,
             GetRequestInner {
                 index: index,
                 ty: ty,

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -104,9 +104,8 @@ where
     {
         let ty = TDocument::name().into();
 
-        RequestBuilder::new(
+        RequestBuilder::initial(
             self.clone(),
-            None,
             IndexRequestInner {
                 index: index,
                 ty: ty,

--- a/src/elastic/src/client/requests/document_put_mapping.rs
+++ b/src/elastic/src/client/requests/document_put_mapping.rs
@@ -94,9 +94,8 @@ where
     {
         let ty = TDocument::name().into();
 
-        RequestBuilder::new(
+        RequestBuilder::initial(
             self.clone(),
-            None,
             PutMappingRequestInner {
                 index: index,
                 ty: ty,

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -9,7 +9,6 @@ use futures::{Future, IntoFuture, Poll};
 use futures_cpupool::CpuPool;
 use serde_json::{self, Map, Value};
 use serde::ser::{Serialize, Serializer};
-use fluent_builder::{FluentBuilder, Override};
 
 use error::{self, Error};
 use client::Client;

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -9,6 +9,7 @@ use futures::{Future, IntoFuture, Poll};
 use futures_cpupool::CpuPool;
 use serde_json::{self, Map, Value};
 use serde::ser::{Serialize, Serializer};
+use fluent_builder::{FluentBuilder, Override};
 
 use error::{self, Error};
 use client::Client;
@@ -193,9 +194,8 @@ where
     {
         let ty = TDocument::name().into();
 
-        RequestBuilder::new(
+        RequestBuilder::initial(
             self.clone(),
-            None,
             UpdateRequestInner {
                 index: index,
                 ty: ty,

--- a/src/elastic/src/client/requests/index_close.rs
+++ b/src/elastic/src/client/requests/index_close.rs
@@ -71,7 +71,7 @@ where
     [send-async]: requests/index_close/type.IndexCloseRequestBuilder.html#send-asynchronously
     */
     pub fn index_close(&self, index: Index<'static>) -> IndexCloseRequestBuilder<TSender> {
-        RequestBuilder::new(self.clone(), None, IndexCloseRequestInner { index: index })
+        RequestBuilder::initial(self.clone(), IndexCloseRequestInner { index: index })
     }
 }
 

--- a/src/elastic/src/client/requests/index_create.rs
+++ b/src/elastic/src/client/requests/index_create.rs
@@ -114,9 +114,8 @@ where
     [documents-mod]: ../types/document/index.html
     */
     pub fn index_create(&self, index: Index<'static>) -> IndexCreateRequestBuilder<TSender, DefaultBody> {
-        RequestBuilder::new(
+        RequestBuilder::initial(
             self.clone(),
-            None,
             IndexCreateRequestInner {
                 index: index,
                 body: empty_body(),

--- a/src/elastic/src/client/requests/index_delete.rs
+++ b/src/elastic/src/client/requests/index_delete.rs
@@ -71,7 +71,7 @@ where
     [send-async]: requests/index_delete/type.IndexDeleteRequestBuilder.html#send-asynchronously
     */
     pub fn index_delete(&self, index: Index<'static>) -> IndexDeleteRequestBuilder<TSender> {
-        RequestBuilder::new(self.clone(), None, IndexDeleteRequestInner { index: index })
+        RequestBuilder::initial(self.clone(), IndexDeleteRequestInner { index: index })
     }
 }
 

--- a/src/elastic/src/client/requests/index_open.rs
+++ b/src/elastic/src/client/requests/index_open.rs
@@ -71,7 +71,7 @@ where
     [send-async]: requests/index_open/type.IndexOpenRequestBuilder.html#send-asynchronously
     */
     pub fn index_open(&self, index: Index<'static>) -> IndexOpenRequestBuilder<TSender> {
-        RequestBuilder::new(self.clone(), None, IndexOpenRequestInner { index: index })
+        RequestBuilder::initial(self.clone(), IndexOpenRequestInner { index: index })
     }
 }
 

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -4,7 +4,6 @@ Request types for the Elasticsearch REST API.
 This module contains implementation details that are useful if you want to customise the request process, but aren't generally important for sending requests.
 */
 
-use std::sync::Arc;
 use futures_cpupool::CpuPool;
 use fluent_builder::FluentBuilder;
 
@@ -120,7 +119,7 @@ where
     # let client = SyncClientBuilder::new().build()?;
     # fn get_req() -> PingRequest<'static> { PingRequest::new() }
     let builder = client.request(get_req())
-                        .params(|p| p.url_param("refresh", true));
+                        .params_fluent(|p| p.url_param("refresh", true));
     # Ok(())
     # }
     ```
@@ -135,7 +134,7 @@ where
     # let client = SyncClientBuilder::new().build()?;
     # fn get_req() -> PingRequest<'static> { PingRequest::new() }
     let builder = client.request(get_req())
-                        .params(|p| p.base_url("http://different-host:9200"));
+                        .params_fluent(|p| p.base_url("http://different-host:9200"));
     # Ok(())
     # }
     ```
@@ -149,6 +148,29 @@ where
         self
     }
 
+    /**
+    Specify default request parameters.
+
+    This method differs from `params_fluent` by not taking any default parameters into account.
+    The `RequestParams` passed in are exactly the `RequestParams` used to build the request.
+    
+    # Examples
+    
+    Add a url param to force an index refresh and send the request to `http://different-host:9200`:
+    
+    ```no_run
+    # extern crate elastic;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = SyncClientBuilder::new().build()?;
+    # fn get_req() -> PingRequest<'static> { PingRequest::new() }
+    let builder = client.request(get_req())
+                        .params(RequestParams::new("http://different-hos:9200").url_param("refresh", true));
+    # Ok(())
+    # }
+    ```
+    */
     pub fn params<I>(mut self, params: I) -> Self
     where
         I: Into<RequestParams>

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -148,6 +148,15 @@ where
 
         self
     }
+
+    pub fn params<I>(mut self, params: I) -> Self
+    where
+        I: Into<RequestParams>
+    {
+        self.params_builder = self.params_builder.value(params.into());
+
+        self
+    }
 }
 
 /**

--- a/src/elastic/src/client/requests/ping.rs
+++ b/src/elastic/src/client/requests/ping.rs
@@ -70,7 +70,7 @@ where
     [send-async]: requests/ping/type.PingRequestBuilder.html#send-asynchronously
     */
     pub fn ping(&self) -> PingRequestBuilder<TSender> {
-        RequestBuilder::new(self.clone(), None, PingRequestInner)
+        RequestBuilder::initial(self.clone(), PingRequestInner)
     }
 }
 

--- a/src/elastic/src/client/requests/raw.rs
+++ b/src/elastic/src/client/requests/raw.rs
@@ -3,6 +3,7 @@ Builders for raw requests.
 */
 
 use std::marker::PhantomData;
+use fluent_builder::TryIntoValue;
 
 use client::Client;
 use client::sender::{NextParams, NodeAddresses, SendableRequest, SendableRequestParams, Sender};
@@ -165,10 +166,10 @@ where
 
         // Only try fetch a next address if an explicit `RequestParams` hasn't been given
         let params = match self.params_builder.try_into_value() {
-            Ok(value) => {
+            TryIntoValue::Value(value) => {
                 SendableRequestParams::Value(value)
             },
-            Err(builder) => {
+            TryIntoValue::Builder(builder) => {
                 SendableRequestParams::Builder {
                     params: client.addresses.next(),
                     builder,

--- a/src/elastic/src/client/requests/raw.rs
+++ b/src/elastic/src/client/requests/raw.rs
@@ -5,7 +5,7 @@ Builders for raw requests.
 use std::marker::PhantomData;
 
 use client::Client;
-use client::sender::{NextParams, NodeAddresses, SendableRequest, Sender};
+use client::sender::{NextParams, NodeAddresses, SendableRequest, SendableRequestParams, Sender};
 use client::requests::{HttpRequest, RequestBuilder};
 
 /**
@@ -162,10 +162,21 @@ where
     pub fn send(self) -> TSender::Response {
         let client = self.client;
         let req = self.inner.req.into();
-        let params_builder = self.params_builder;
-        let params = client.addresses.next();
 
-        let req = SendableRequest::new(req, params, params_builder);
+        // Only try fetch a next address if an explicit `RequestParams` hasn't been given
+        let params = match self.params_builder.try_into_value() {
+            Ok(value) => {
+                SendableRequestParams::Value(value)
+            },
+            Err(builder) => {
+                SendableRequestParams::Builder {
+                    params: client.addresses.next(),
+                    builder,
+                }
+            }
+        };
+
+        let req = SendableRequest::new(req, params);
 
         client.sender.send(req)
     }

--- a/src/elastic/src/client/requests/raw.rs
+++ b/src/elastic/src/client/requests/raw.rs
@@ -79,7 +79,7 @@ where
         TRequest: Into<HttpRequest<'static, TBody>>,
         TBody: Into<TSender::Body>,
     {
-        RequestBuilder::new(self.clone(), None, RawRequestInner::new(req))
+        RequestBuilder::initial(self.clone(), RawRequestInner::new(req))
     }
 }
 

--- a/src/elastic/src/client/requests/search.rs
+++ b/src/elastic/src/client/requests/search.rs
@@ -123,7 +123,7 @@ where
     where
         TDocument: DeserializeOwned,
     {
-        RequestBuilder::new(self.clone(), None, SearchRequestInner::new(empty_body()))
+        RequestBuilder::initial(self.clone(), SearchRequestInner::new(empty_body()))
     }
 }
 

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -45,20 +45,26 @@ This type encapsulates the state needed between a [`Client`][Client] and a [`Sen
 pub struct SendableRequest<TRequest, TParams, TBody> {
     correlation_id: Uuid,
     inner: TRequest,
-    params: TParams,
-    params_builder: FluentBuilder<RequestParams>,
+    params: SendableRequestParams<TParams>,
     _marker: PhantomData<TBody>,
 }
 
 impl<TRequest, TParams, TBody> SendableRequest<TRequest, TParams, TBody> {
-    pub(crate) fn new(inner: TRequest, params: TParams, params_builder: FluentBuilder<RequestParams>) -> Self {
+    pub(crate) fn new(inner: TRequest, params: SendableRequestParams<TParams>) -> Self {
         SendableRequest {
             correlation_id: Uuid::new_v4(),
             inner: inner,
             params: params,
-            params_builder: params_builder,
             _marker: PhantomData,
         }
+    }
+}
+
+pub(crate) enum SendableRequestParams<TParams> {
+    Value(RequestParams),
+    Builder {
+        params: TParams,
+        builder: FluentBuilder<RequestParams>,
     }
 }
 

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -13,7 +13,7 @@ Some notable types include:
 [Client]: ../struct.Client.html
 */
 
-use fluent_builder::FluentBuilder;
+use fluent_builder::{FluentBuilder, StatefulFluentBuilder};
 
 pub mod static_nodes;
 pub mod sniffed_nodes;
@@ -170,7 +170,34 @@ enum NodeAddressesInner<TSender> {
 
 enum NodeAddressesBuilder {
     Static(Vec<NodeAddress>),
-    Sniffed(SniffedNodesBuilder),
+    Sniffed(StatefulFluentBuilder<SniffedNodesBuilder, NodeAddress>),
+}
+
+impl NodeAddressesBuilder {
+    fn sniff_nodes(mut self, builder: SniffedNodesBuilder) -> Self {
+        match self {
+            NodeAddressesBuilder::Sniffed(fluent_builder) => {
+                NodeAddressesBuilder::Sniffed(fluent_builder.value(builder))
+            },
+            _ => {
+                NodeAddressesBuilder::Sniffed(StatefulFluentBuilder::from_value(builder.into()))
+            }
+        }
+    }
+
+    fn sniff_nodes_fluent<F>(self, address: NodeAddress, fleunt_method: F) -> Self
+    where
+        F: FnOnce(SniffedNodesBuilder) -> SniffedNodesBuilder + 'static,
+    {
+        match self {
+            NodeAddressesBuilder::Sniffed(fluent_builder) => {
+                NodeAddressesBuilder::Sniffed(fluent_builder.fluent(address.into(), fleunt_method).boxed())
+            },
+            _ => {
+                NodeAddressesBuilder::Sniffed(StatefulFluentBuilder::from_fluent(address.into(), fleunt_method).boxed())
+            }
+        }
+    }
 }
 
 impl Default for NodeAddressesBuilder {
@@ -188,7 +215,7 @@ impl NodeAddressesBuilder {
                 NodeAddresses::static_nodes(nodes)
             }
             NodeAddressesBuilder::Sniffed(builder) => {
-                let nodes = builder.build(params, sender);
+                let nodes = builder.into_value(|node| SniffedNodesBuilder::new(node)).build(params, sender);
 
                 NodeAddresses::sniffed_nodes(nodes)
             }

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -13,6 +13,8 @@ Some notable types include:
 [Client]: ../struct.Client.html
 */
 
+use fluent_builder::FluentBuilder;
+
 pub mod static_nodes;
 pub mod sniffed_nodes;
 
@@ -44,12 +46,12 @@ pub struct SendableRequest<TRequest, TParams, TBody> {
     correlation_id: Uuid,
     inner: TRequest,
     params: TParams,
-    params_builder: Option<Arc<Fn(RequestParams) -> RequestParams>>,
+    params_builder: FluentBuilder<RequestParams>,
     _marker: PhantomData<TBody>,
 }
 
 impl<TRequest, TParams, TBody> SendableRequest<TRequest, TParams, TBody> {
-    pub(crate) fn new(inner: TRequest, params: TParams, params_builder: Option<Arc<Fn(RequestParams) -> RequestParams>>) -> Self {
+    pub(crate) fn new(inner: TRequest, params: TParams, params_builder: FluentBuilder<RequestParams>) -> Self {
         SendableRequest {
             correlation_id: Uuid::new_v4(),
             inner: inner,

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -174,7 +174,7 @@ enum NodeAddressesBuilder {
 }
 
 impl NodeAddressesBuilder {
-    fn sniff_nodes(mut self, builder: SniffedNodesBuilder) -> Self {
+    fn sniff_nodes(self, builder: SniffedNodesBuilder) -> Self {
         match self {
             NodeAddressesBuilder::Sniffed(fluent_builder) => {
                 NodeAddressesBuilder::Sniffed(fluent_builder.value(builder))

--- a/src/elastic/src/client/sender/sniffed_nodes/mod.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/mod.rs
@@ -134,6 +134,17 @@ impl SniffedNodesBuilder {
     }
 
     /**
+    Specify a given base address.
+    */
+    pub fn base_url<I>(mut self, address: I) -> Self
+    where
+        I: Into<NodeAddress>,
+    {
+        self.base_url = address.into();
+        self
+    }
+
+    /**
     Specify a minimum duration to wait before refreshing the set of node addresses.
     */
     pub fn wait(mut self, wait: Duration) -> Self {

--- a/src/elastic/src/client/sender/sniffed_nodes/mod.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/mod.rs
@@ -30,7 +30,6 @@ use std::time::{Duration, Instant};
 use std::sync::{Arc, RwLock};
 use url::Url;
 use futures::{Future, IntoFuture};
-use fluent_builder::FluentBuilder;
 
 use client::sender::static_nodes::StaticNodes;
 use client::sender::{AsyncSender, NextParams, NodeAddress, PreRequestParams, RequestParams, SendableRequest, SendableRequestParams, Sender, SyncSender};

--- a/src/elastic/src/client/sender/sniffed_nodes/mod.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/mod.rs
@@ -33,7 +33,7 @@ use futures::{Future, IntoFuture};
 use fluent_builder::FluentBuilder;
 
 use client::sender::static_nodes::StaticNodes;
-use client::sender::{AsyncSender, NextParams, NodeAddress, PreRequestParams, RequestParams, SendableRequest, Sender, SyncSender};
+use client::sender::{AsyncSender, NextParams, NodeAddress, PreRequestParams, RequestParams, SendableRequest, SendableRequestParams, Sender, SyncSender};
 use client::requests::{DefaultBody, NodesInfoRequest};
 use error::{self, Error};
 use private;
@@ -229,7 +229,7 @@ impl<TSender> SniffedNodes<TSender> {
     }
 
     fn sendable_request(&self) -> SendableRequest<NodesInfoRequest<'static>, RequestParams, DefaultBody> {
-        SendableRequest::new(NodesInfoRequest::new(), self.refresh_params.clone(), FluentBuilder::new())
+        SendableRequest::new(NodesInfoRequest::new(), SendableRequestParams::Value(self.refresh_params.clone()))
     }
 
     fn finish_refresh(inner: &RwLock<SniffedNodesInner>, refresh_params: &RequestParams, fresh_nodes: Result<NodesInfoResponse, Error>) -> Result<RequestParams, Error> {

--- a/src/elastic/src/client/sender/sniffed_nodes/mod.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/mod.rs
@@ -30,6 +30,8 @@ use std::time::{Duration, Instant};
 use std::sync::{Arc, RwLock};
 use url::Url;
 use futures::{Future, IntoFuture};
+use fluent_builder::FluentBuilder;
+
 use client::sender::static_nodes::StaticNodes;
 use client::sender::{AsyncSender, NextParams, NodeAddress, PreRequestParams, RequestParams, SendableRequest, Sender, SyncSender};
 use client::requests::{DefaultBody, NodesInfoRequest};
@@ -227,7 +229,7 @@ impl<TSender> SniffedNodes<TSender> {
     }
 
     fn sendable_request(&self) -> SendableRequest<NodesInfoRequest<'static>, RequestParams, DefaultBody> {
-        SendableRequest::new(NodesInfoRequest::new(), self.refresh_params.clone(), None)
+        SendableRequest::new(NodesInfoRequest::new(), self.refresh_params.clone(), FluentBuilder::new())
     }
 
     fn finish_refresh(inner: &RwLock<SniffedNodesInner>, refresh_params: &RequestParams, fresh_nodes: Result<NodesInfoResponse, Error>) -> Result<RequestParams, Error> {

--- a/src/elastic/src/lib.rs
+++ b/src/elastic/src/lib.rs
@@ -299,6 +299,7 @@ extern crate serde_json;
 extern crate tokio_core;
 extern crate url;
 extern crate uuid;
+extern crate fluent_builder;
 
 pub mod error;
 pub use error::Error;

--- a/src/elastic/src/lib.rs
+++ b/src/elastic/src/lib.rs
@@ -63,7 +63,7 @@ use elastic::http::header::Authorization;
 
 let builder = SyncClientBuilder::new()
     .static_node("http://es_host:9200")
-    .params(|p| p
+    .params_fluent(|p| p
         .url_param("pretty", true)
         .header(Authorization("let me in".to_owned())));
 
@@ -84,7 +84,7 @@ Individual requests can override these parameter values:
 let client = SyncClientBuilder::new().build()?;
 
 let response = client.search::<Value>()
-                     .params(|p| p.url_param("pretty", false))
+                     .params_fluent(|p| p.url_param("pretty", false))
                      .send()?;
 # Ok(())
 # }
@@ -239,7 +239,6 @@ for hit in response.hits() {
 
 This crate is mostly a meta-package composed of a number of smaller pieces including:
 
-- `elastic_reqwest` HTTP transport
 - `elastic_requests` API request builders
 - `elastic_responses` API response parsers
 - `elastic_types` tools for document and mapping APIs

--- a/tests/run/src/document/delete.rs
+++ b/tests/run/src/document/delete.rs
@@ -35,14 +35,14 @@ impl IntegrationTest for Delete {
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
         let index_res = client
             .document_index(index(INDEX), id(ID), Doc { id: ID })
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let pre_delete_res = client.document_get(index(INDEX), id(ID)).send();
 
         let delete_res = client
             .document_delete::<Doc>(index(INDEX), id(ID))
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let post_delete_res = client.document_get(index(INDEX), id(ID)).send();

--- a/tests/run/src/document/simple_index_get.rs
+++ b/tests/run/src/document/simple_index_get.rs
@@ -45,7 +45,7 @@ impl IntegrationTest for SimpleIndexGet {
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
         let index_res = client
             .document_index(index(INDEX), id(ID), doc())
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let get_res = client.document_get(index(INDEX), id(ID)).send();

--- a/tests/run/src/document/update_with_doc.rs
+++ b/tests/run/src/document/update_with_doc.rs
@@ -44,7 +44,7 @@ impl IntegrationTest for UpdateWithDoc {
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
         let index_res = client
             .document_index(index(INDEX), id(ID), doc())
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let update_res = client
@@ -53,7 +53,7 @@ impl IntegrationTest for UpdateWithDoc {
                 id: ID,
                 title: EXPECTED_TITLE.to_owned(),
             })
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let get_res = client.document_get(index(INDEX), id(ID)).send();

--- a/tests/run/src/document/update_with_inline_script.rs
+++ b/tests/run/src/document/update_with_inline_script.rs
@@ -39,7 +39,7 @@ impl IntegrationTest for UpdateWithInlineScript {
 
         let index_res = client
             .document_index(index(INDEX), id(ID), doc())
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         Box::new(delete_res.then(|_| index_res).map(|_| ()))
@@ -50,7 +50,7 @@ impl IntegrationTest for UpdateWithInlineScript {
         let update_res = client
             .document_update::<Doc>(index(INDEX), id(ID))
             .script(format!("ctx._source.title = \"{}\"", EXPECTED_TITLE))
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let get_res = client.document_get(index(INDEX), id(ID)).send();

--- a/tests/run/src/document/update_with_script.rs
+++ b/tests/run/src/document/update_with_script.rs
@@ -39,7 +39,7 @@ impl IntegrationTest for UpdateWithScript {
 
         let index_res = client
             .document_index(index(INDEX), id(ID), doc())
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         Box::new(delete_res.then(|_| index_res).map(|_| ()))
@@ -53,7 +53,7 @@ impl IntegrationTest for UpdateWithScript {
                 "ctx._source.title = params.newTitle",
                 |s| s.param("newTitle", EXPECTED_TITLE),
             )
-            .params(|p| p.url_param("refresh", true))
+            .params_fluent(|p| p.url_param("refresh", true))
             .send();
 
         let get_res = client.document_get(index(INDEX), id(ID)).send();

--- a/tests/run/src/search/empty_query.rs
+++ b/tests/run/src/search/empty_query.rs
@@ -30,7 +30,7 @@ impl IntegrationTest for EmptyQuery {
         let index_reqs = future::join_all((0..10).into_iter().map(move |i| {
             client
                 .document_index(index(INDEX), id(i), Doc { id: i })
-                .params(|p| p.url_param("refresh", true))
+                .params_fluent(|p| p.url_param("refresh", true))
                 .send()
         }));
 

--- a/tests/run/src/search/raw_query_string.rs
+++ b/tests/run/src/search/raw_query_string.rs
@@ -30,7 +30,7 @@ impl IntegrationTest for RawQueryString {
         let index_reqs = future::join_all((0..10).into_iter().map(move |i| {
             client
                 .document_index(index(INDEX), id(i), Doc { id: i })
-                .params(|p| p.url_param("refresh", true))
+                .params_fluent(|p| p.url_param("refresh", true))
                 .send()
         }));
 


### PR DESCRIPTION
This is a start for making the various builders on requests and the client consistent. In any case where we have an inner builder we should:

- Offer a convenient `_fluent` method that allows configuring the builder without explicitly creating it (this method does not stack)
- Support any `T: Into<TBuilder>` so when there's an obvious default that can be passed in instead

There are some cases where we can't use `FluentBuilder` itself, like `document_update` with a script, since it changes the builder type, but can in other places.