### PR TITLE
Loosen version bound on quick-error

### DIFF
--- a/src/reqwest/Cargo.toml
+++ b/src/reqwest/Cargo.toml
@@ -14,7 +14,7 @@ elastic_requests = { version = "~0.20.0", path = "../requests" }
 elastic_responses = { version = "~0.20.2", path = "../responses" }
 reqwest = { version = "~0.8.0", features = ["unstable"] }
 url = "~1"
-bytes = "0.4.5"
+bytes = "~0.4.5"
 tokio-core = "~0.1.9"
 futures = "~0.1.16"
 serde_json = "~1"

--- a/src/responses/Cargo.toml
+++ b/src/responses/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 serde = "~1"
 serde_derive = "~1"
 serde_json = "~1"
-quick-error = "~1.1"
+quick-error = "~1"
 
 [dev-dependencies]
 json_str = "^0.*"


### PR DESCRIPTION
Part of #283 

The bound on `quick-error` and `bytes` are tighter than they need to be.