### PR TITLE
Add index_exists client method

### DIFF
--- a/src/elastic/examples/index.rs
+++ b/src/elastic/examples/index.rs
@@ -35,8 +35,10 @@ fn run() -> Result<(), Box<Error>> {
         timestamp: Date::now(),
     };
 
-    // Create the index
-    client.index_create(sample_index()).send()?;
+    // Create the index if it doesn't exist
+    if !client.index_exists(sample_index()).send()?.exists() {
+        client.index_create(sample_index()).send()?;
+    }
 
     // Add the document mapping (optional, but makes sure `timestamp` is mapped as a `date`)
     client

--- a/src/elastic/src/client/async.rs
+++ b/src/elastic/src/client/async.rs
@@ -67,8 +67,9 @@ impl Sender for AsyncSender {
         let req = req.into();
 
         info!(
-            "Elasticsearch Request: correlation_id: '{}', path: '{}'",
+            "Elasticsearch Request: correlation_id: '{}', method: '{:?}', path: '{}'",
             correlation_id,
+            req.method,
             req.url.as_ref()
         );
 

--- a/src/elastic/src/client/requests/index_exists.rs
+++ b/src/elastic/src/client/requests/index_exists.rs
@@ -1,0 +1,204 @@
+/*!
+Builders for [index exists requests][docs-index-exists].
+
+[docs-index-exists]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
+*/
+
+use futures::{Future, Poll};
+
+use error::*;
+use client::{AsyncSender, Client, Sender, SyncSender};
+use client::requests::RequestBuilder;
+use client::requests::params::Index;
+use client::requests::endpoints::IndicesExistsRequest;
+use client::requests::raw::RawRequestInner;
+use client::responses::IndicesExistsResponse;
+
+/** 
+An [index exists request][docs-index-exists] builder that can be configured before sending. 
+
+Call [`Client.index_exists`][Client.index_exists] to get an `IndexExistsRequestBuilder`.
+The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was opend from.
+
+[docs-index-exists]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
+[send-sync]: #send-synchronously
+[send-async]: #send-asynchronously
+[Client.index_exists]: ../../struct.Client.html#index-exists-request
+*/
+pub type IndexExistsRequestBuilder<TSender> = RequestBuilder<TSender, IndexExistsRequestInner>;
+
+#[doc(hidden)]
+pub struct IndexExistsRequestInner {
+    index: Index<'static>,
+}
+
+/**
+# Open index request
+*/
+impl<TSender> Client<TSender>
+where
+    TSender: Sender,
+{
+    /** 
+    Open an [`IndexExistsRequestBuilder`][IndexExistsRequestBuilder] with this `Client` that can be configured before sending.
+
+    For more details, see:
+
+    - [send synchronously][send-sync]
+    - [send asynchronously][send-async]
+    
+    # Examples
+    
+    Open an index called `myindex`:
+    
+    ```no_run
+    # extern crate elastic;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = SyncClientBuilder::new().build()?;
+    let response = client.index_exists(index("myindex")).send()?;
+
+    assert!(response.exists());
+    # Ok(())
+    # }
+    ```
+
+    [IndexExistsRequestBuilder]: requests/index_exists/type.IndexExistsRequestBuilder.html
+    [builder-methods]: requests/index_exists/type.IndexExistsRequestBuilder.html#builder-methods
+    [send-sync]: requests/index_exists/type.IndexExistsRequestBuilder.html#send-synchronously
+    [send-async]: requests/index_exists/type.IndexExistsRequestBuilder.html#send-asynchronously
+    */
+    pub fn index_exists(&self, index: Index<'static>) -> IndexExistsRequestBuilder<TSender> {
+        RequestBuilder::new(self.clone(), None, IndexExistsRequestInner { index: index })
+    }
+}
+
+impl IndexExistsRequestInner {
+    fn into_request(self) -> IndicesExistsRequest<'static> {
+        IndicesExistsRequest::for_index(self.index)
+    }
+}
+
+/**
+# Send synchronously
+*/
+impl IndexExistsRequestBuilder<SyncSender> {
+    /**
+    Send an `IndexExistsRequestBuilder` synchronously using a [`SyncClient`][SyncClient].
+
+    This will block the current thread until a response arrives and is deserialised.
+
+    # Examples
+    
+    Open an index called `myindex`:
+    
+    ```no_run
+    # extern crate elastic;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = SyncClientBuilder::new().build()?;
+    let response = client.index_exists(index("myindex")).send()?;
+
+    assert!(response.exists());
+    # Ok(())
+    # }
+    ```
+
+    [SyncClient]: ../../type.SyncClient.html
+    */
+    pub fn send(self) -> Result<IndicesExistsResponse> {
+        let req = self.inner.into_request();
+
+        RequestBuilder::new(self.client, self.params, RawRequestInner::new(req))
+            .send()?
+            .into_response()
+    }
+}
+
+/**
+# Send asynchronously
+*/
+impl IndexExistsRequestBuilder<AsyncSender> {
+    /**
+    Send an `IndexExistsRequestBuilder` asynchronously using an [`AsyncClient`][AsyncClient].
+    
+    This will return a future that will resolve to the deserialised command response.
+
+    # Examples
+    
+    Open an index called `myindex`:
+    
+    ```no_run
+    # extern crate futures;
+    # extern crate tokio_core;
+    # extern crate elastic;
+    # use futures::Future;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let core = tokio_core::reactor::Core::new()?;
+    # let client = AsyncClientBuilder::new().build(&core.handle())?;
+    let future = client.index_exists(index("myindex")).send();
+
+    future.and_then(|response| {
+        assert!(response.exists());
+
+        Ok(())
+    });
+    # Ok(())
+    # }
+    ```
+
+    [AsyncClient]: ../../type.AsyncClient.html
+    */
+    pub fn send(self) -> Pending {
+        let req = self.inner.into_request();
+
+        let res_future = RequestBuilder::new(self.client, self.params, RawRequestInner::new(req))
+            .send()
+            .and_then(|res| res.into_response());
+
+        Pending::new(res_future)
+    }
+}
+
+/** A future returned by calling `send`. */
+pub struct Pending {
+    inner: Box<Future<Item = IndicesExistsResponse, Error = Error>>,
+}
+
+impl Pending {
+    fn new<F>(fut: F) -> Self
+    where
+        F: Future<Item = IndicesExistsResponse, Error = Error> + 'static,
+    {
+        Pending {
+            inner: Box::new(fut),
+        }
+    }
+}
+
+impl Future for Pending {
+    type Item = IndicesExistsResponse;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prelude::*;
+
+    #[test]
+    fn default_request() {
+        let client = SyncClientBuilder::new().build().unwrap();
+
+        let req = client.index_exists(index("testindex")).inner.into_request();
+
+        assert_eq!("/testindex", req.url.as_ref());
+    }
+}

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -40,10 +40,12 @@ pub mod index_create;
 pub mod index_open;
 pub mod index_close;
 pub mod index_delete;
+pub mod index_exists;
 pub use self::index_create::IndexCreateRequestBuilder;
 pub use self::index_open::IndexOpenRequestBuilder;
 pub use self::index_close::IndexCloseRequestBuilder;
 pub use self::index_delete::IndexDeleteRequestBuilder;
+pub use self::index_exists::IndexExistsRequestBuilder;
 
 // Misc requests
 pub mod ping;

--- a/src/elastic/src/client/responses/mod.rs
+++ b/src/elastic/src/client/responses/mod.rs
@@ -16,7 +16,7 @@ pub mod parse;
 pub use self::sync::*;
 pub use self::async::*;
 
-pub use elastic_reqwest::res::{BulkErrorsResponse, BulkResponse, CommandResponse, DeleteResponse, GetResponse, IndexResponse, PingResponse, SearchResponse, Shards, UpdateResponse};
+pub use elastic_reqwest::res::{BulkErrorsResponse, BulkResponse, CommandResponse, DeleteResponse, GetResponse, IndicesExistsResponse, IndexResponse, PingResponse, SearchResponse, Shards, UpdateResponse};
 
 pub use elastic_reqwest::res::search;
 pub use elastic_reqwest::res::bulk;
@@ -24,7 +24,7 @@ pub use elastic_reqwest::res::bulk;
 pub mod prelude {
     /*! A glob import for convenience. */
 
-    pub use super::{BulkErrorsResponse, BulkResponse, CommandResponse, DeleteResponse, GetResponse, IndexResponse, PingResponse, SearchResponse, Shards, UpdateResponse};
+    pub use super::{BulkErrorsResponse, BulkResponse, CommandResponse, DeleteResponse, GetResponse, IndicesExistsResponse, IndexResponse, PingResponse, SearchResponse, Shards, UpdateResponse};
 
     pub use super::async::AsyncResponseBuilder;
     pub use super::sync::SyncResponseBuilder;

--- a/src/elastic/src/client/sync.rs
+++ b/src/elastic/src/client/sync.rs
@@ -53,8 +53,9 @@ impl Sender for SyncSender {
         let req = req.into();
 
         info!(
-            "Elasticsearch Request: correlation_id: '{}', path: '{}'",
+            "Elasticsearch Request: correlation_id: '{}', method: '{:?}', path: '{}'",
             correlation_id,
+            req.method,
             req.url.as_ref()
         );
 

--- a/src/responses/src/indices_exists.rs
+++ b/src/responses/src/indices_exists.rs
@@ -1,0 +1,29 @@
+/*!
+Response types for an [index exists request](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html).
+*/
+
+use parsing::{HttpResponseHead, IsOk, MaybeOkResponse, ResponseBody, Unbuffered};
+use error::*;
+
+/** Response for an [index exists request](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html). */
+#[derive(Deserialize, Debug)]
+pub struct IndicesExistsResponse {
+    exists: bool
+}
+
+impl IndicesExistsResponse {
+    /** Whether or not the index exists. */
+    pub fn exists(&self) -> bool {
+        self.exists
+    }
+}
+
+impl IsOk for IndicesExistsResponse {
+    fn is_ok<B: ResponseBody>(head: HttpResponseHead, body: Unbuffered<B>) -> Result<MaybeOkResponse<B>, ParseResponseError> {
+        match head.status() {
+            200...299 => Ok(MaybeOkResponse::ok(json!({ "exists": true }))),
+            404 => Ok(MaybeOkResponse::ok(json!({ "exists": false }))),
+            _ => Ok(MaybeOkResponse::err(body)),
+        }
+    }
+}

--- a/src/responses/src/lib.rs
+++ b/src/responses/src/lib.rs
@@ -134,6 +134,7 @@ extern crate serde_derive;
 extern crate quick_error;
 
 extern crate serde;
+#[macro_use]
 extern crate serde_json;
 
 pub mod error;
@@ -149,6 +150,8 @@ pub mod search;
 pub mod bulk;
 mod index;
 
+mod indices_exists;
+
 pub use self::common::*;
 pub use self::command::*;
 pub use self::ping::*;
@@ -158,6 +161,8 @@ pub use self::update::*;
 pub use self::search::SearchResponse;
 pub use self::bulk::{BulkErrorsResponse, BulkResponse};
 pub use self::index::*;
+
+pub use self::indices_exists::*;
 
 pub use self::parsing::parse;
 

--- a/src/responses/tests/indices_exists/mod.rs
+++ b/src/responses/tests/indices_exists/mod.rs
@@ -1,0 +1,18 @@
+extern crate elastic_responses;
+extern crate serde_json;
+
+use elastic_responses::*;
+
+#[test]
+fn success_parse_response_exists() {
+    let deserialized = parse::<IndicesExistsResponse>().from_slice(200, b"").unwrap();
+
+    assert!(deserialized.exists());
+}
+
+#[test]
+fn success_parse_response_not_exists() {
+    let deserialized = parse::<IndicesExistsResponse>().from_slice(404, b"").unwrap();
+
+    assert!(!deserialized.exists());
+}

--- a/src/responses/tests/mod.rs
+++ b/src/responses/tests/mod.rs
@@ -16,3 +16,4 @@ pub mod get;
 pub mod search;
 pub mod bulk;
 pub mod index;
+pub mod indices_exists;


### PR DESCRIPTION
Part of #256 

- Adds an `index_exists` method to the client
- Adds support for specifying a new response body as json when determining whether or not the response is ok. This makes it possible to deserialise an `IndexExistsResponse` type with a boolean of whether or not the index exists, even though the response actually contains no data