### PR TITLE
Add a maybe_async method using serde_pool

### DIFF
--- a/src/types/benches/mod.rs
+++ b/src/types/benches/mod.rs
@@ -1,11 +1,12 @@
-#![feature(plugin, test)]
-#![plugin(json_str)]
+#![feature(test)]
 
 extern crate geo as georust;
 extern crate geojson;
 extern crate serde;
 extern crate serde_json;
 extern crate test;
+#[macro_use]
+extern crate json_str;
 pub extern crate chrono;
 
 extern crate elastic_types;


### PR DESCRIPTION
For async client methods with a serializable body, we offload the serialisation to a cpu pool if the caller has specified one. The slightly dubious rationale for this is to support offloading as much from the `tokio` thread as possible. This PR just tidies some of that up so we don't duplicate the code for each request that might be async.