### PR TITLE
Allow getting raw aggregations

### DIFF
--- a/src/responses/src/search.rs
+++ b/src/responses/src/search.rs
@@ -133,6 +133,13 @@ impl<T> SearchResponse<T> {
     pub fn aggs(&self) -> Aggs {
         Aggs::new(self.aggregations.as_ref())
     }
+
+    /**
+    Get a reference to the raw aggregation value.
+    */
+    pub fn aggs_raw(&self) -> Option<&Value> {
+        self.aggregations.as_ref().map(|wrapper| &wrapper.0)
+    }
 }
 
 impl<T: DeserializeOwned> IsOk for SearchResponse<T> {

--- a/src/responses/tests/search/mod.rs
+++ b/src/responses/tests/search/mod.rs
@@ -107,6 +107,12 @@ fn success_parse_simple_nested_aggs() {
         .unwrap();
 
     assert_eq!(deserialized.aggs().count(), 124);
+
+    let doc_count = deserialized
+        .aggs_raw()
+        .and_then(|aggs| aggs["timechart"]["buckets"][0]["doc_count"].as_u64());
+
+    assert_eq!(Some(101), doc_count);
 }
 
 #[test]


### PR DESCRIPTION
Closes #304 

This shouldn't affect #257 because we're going to store aggregations as `Value`s internally anyways before attempting to interpret them as the various aggregation types.

cc @kardeiz How does this look?