### PR TITLE
Fix up a bug attempting to use default mapping fields

### DIFF
--- a/src/elastic/src/client/mod.rs
+++ b/src/elastic/src/client/mod.rs
@@ -459,10 +459,10 @@ For more details see the [`responses`][responses-mod] module.
 [AsyncClientBuilder]: struct.AsyncClientBuilder.html
 [Client.request]: struct.Client.html#method.request
 [Client.search]: struct.Client.html#search-request
-[Client.document_get]: struct.Client.html#get-document
-[Client.document_update]: struct.Client.html#update-document
-[Client.document_delete]: struct.Client.html#delete-document
-[Client.document_index]: struct.Client.html#index-request
+[Client.document_get]: struct.Client.html#get-document-request
+[Client.document_update]: struct.Client.html#update-document-request
+[Client.document_delete]: struct.Client.html#delete-document-request
+[Client.document_index]: struct.Client.html#index-document-request
 [Client.document_put_mapping]: struct.Client.html#method.document_put_mapping
 [Client.index_create]: struct.Client.html#create-index-request
 [Client.index_open]: struct.Client.html#open-index-request

--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -38,7 +38,7 @@ pub struct DeleteRequestInner<TDocument> {
 }
 
 /**
-# Delete document
+# Delete document request
 */
 impl<TSender> Client<TSender>
 where

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -39,7 +39,7 @@ pub struct GetRequestInner<TDocument> {
 }
 
 /**
-# Get document
+# Get document request
 */
 impl<TSender> Client<TSender>
 where

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -39,7 +39,7 @@ pub struct IndexRequestInner<TDocument> {
 }
 
 /**
-# Index document
+# Index document request
 */
 impl<TSender> Client<TSender>
 where

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -41,7 +41,7 @@ pub struct UpdateRequestInner<TBody> {
 }
 
 /**
-# Update document
+# Update document request
 */
 impl<TSender> Client<TSender>
 where

--- a/src/types/src/private/impls.rs
+++ b/src/types/src/private/impls.rs
@@ -10,7 +10,7 @@ pub trait DefaultFieldType {}
 
 /** A mapping implementation for a non-core type, or anywhere it's ok for Elasticsearch to infer the mapping at index-time. */
 #[derive(Debug, PartialEq, Default, Clone)]
-struct DefaultMapping;
+pub struct DefaultMapping;
 impl FieldMapping<()> for DefaultMapping {
     type DocumentField = DocumentField<DefaultMapping, ()>;
 }

--- a/tests/run/src/document/compile_test.rs
+++ b/tests/run/src/document/compile_test.rs
@@ -1,0 +1,12 @@
+/**
+Tests for ensuring documents can be derived.
+*/
+
+use std::collections::HashMap;
+
+#[derive(ElasticType, Serialize, Deserialize)]
+pub struct Sample {
+    pub labels: HashMap<String, String>,
+    pub value: f64,
+    pub timestamp: i64,
+}

--- a/tests/run/src/document/mod.rs
+++ b/tests/run/src/document/mod.rs
@@ -1,5 +1,7 @@
 use run_tests::{test, Test};
 
+mod compile_test;
+
 mod simple_index_get;
 mod update_with_doc;
 mod update_with_script;


### PR DESCRIPTION
Fixes #309 

The `DefaultMapping` type being private is causing issues deriving `ElasticType` for structures with fields that use the default mapping, like `HashMap`.