### PR TITLE
Make the id param optional on document_index

### DIFF
--- a/benches/prepare/src/main.rs
+++ b/benches/prepare/src/main.rs
@@ -45,6 +45,6 @@ fn main() {
             timestamp: Date::now(),
         };
 
-        client.document_index(index(), id(i), &doc).send().unwrap();
+        client.document_index(index(), &doc).id(i).send().unwrap();
     }
 }

--- a/src/elastic/examples/basic.rs
+++ b/src/elastic/examples/basic.rs
@@ -43,6 +43,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap();
 }

--- a/src/elastic/examples/basic_async.rs
+++ b/src/elastic/examples/basic_async.rs
@@ -59,6 +59,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap();
 }

--- a/src/elastic/examples/bulk.rs
+++ b/src/elastic/examples/bulk.rs
@@ -52,6 +52,6 @@ fn bulk_body() -> String {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/bulk_async.rs
+++ b/src/elastic/examples/bulk_async.rs
@@ -64,6 +64,6 @@ fn bulk_body() -> String {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/custom_response.rs
+++ b/src/elastic/examples/custom_response.rs
@@ -68,6 +68,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/get.rs
+++ b/src/elastic/examples/get.rs
@@ -52,6 +52,6 @@ fn run() -> Result<(), Box<StdError>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/index.rs
+++ b/src/elastic/examples/index.rs
@@ -56,7 +56,7 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap();
 }
 

--- a/src/elastic/examples/index.rs
+++ b/src/elastic/examples/index.rs
@@ -46,8 +46,10 @@ fn run() -> Result<(), Box<Error>> {
         .send()?;
 
     // Index the document
+    let doc_id = doc.id;
     client
-        .document_index(sample_index(), id(doc.id), doc)
+        .document_index(sample_index(), doc)
+        .id(doc_id)
         .send()?;
 
     Ok(())

--- a/src/elastic/examples/load_balanced_async.rs
+++ b/src/elastic/examples/load_balanced_async.rs
@@ -39,6 +39,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap();
 }

--- a/src/elastic/examples/ping.rs
+++ b/src/elastic/examples/ping.rs
@@ -21,6 +21,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/pre_send.rs
+++ b/src/elastic/examples/pre_send.rs
@@ -55,6 +55,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/raw.rs
+++ b/src/elastic/examples/raw.rs
@@ -41,6 +41,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/typed.rs
+++ b/src/elastic/examples/typed.rs
@@ -123,6 +123,6 @@ fn search(client: &SyncClient, query: &'static str) -> Result<SearchResponse<MyT
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/typed.rs
+++ b/src/elastic/examples/typed.rs
@@ -98,8 +98,10 @@ fn put_index(client: &SyncClient) -> Result<(), Error> {
 }
 
 fn put_doc(client: &SyncClient, doc: MyType) -> Result<(), Error> {
+    let doc_id = doc.id;
     client
-        .document_index(sample_index(), id(doc.id), doc)
+        .document_index(sample_index(), doc)
+        .id(doc_id)
         .params_fluent(|p| p.url_param("refresh", true))
         .send()?;
 

--- a/src/elastic/examples/typed_async.rs
+++ b/src/elastic/examples/typed_async.rs
@@ -146,6 +146,6 @@ fn search(client: AsyncClient, query: &'static str) -> Box<Future<Item = SearchR
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/src/elastic/examples/typed_async.rs
+++ b/src/elastic/examples/typed_async.rs
@@ -117,8 +117,11 @@ fn put_index(client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
 }
 
 fn put_doc(client: AsyncClient, doc: MyType) -> Box<Future<Item = (), Error = Error>> {
+    let doc_id = doc.id;
+
     let index_doc = client
-        .document_index(sample_index(), id(doc.id), doc)
+        .document_index(sample_index(), doc)
+        .id(doc_id)
         .params_fluent(|p| p.url_param("refresh", true))
         .send()
         .map(|_| ());

--- a/src/elastic/examples/update.rs
+++ b/src/elastic/examples/update.rs
@@ -49,7 +49,8 @@ fn run() -> Result<(), Box<Error>> {
 
     // Index the document
     client
-        .document_index(sample_index(), id(doc_id), doc)
+        .document_index(sample_index(), doc)
+        .id(doc_id)
         .params_fluent(|p| p.url_param("refresh", true))
         .send()?;
 

--- a/src/elastic/examples/update.rs
+++ b/src/elastic/examples/update.rs
@@ -66,7 +66,7 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap();
 }
 

--- a/src/elastic/src/lib.rs
+++ b/src/elastic/src/lib.rs
@@ -165,7 +165,9 @@ let doc = MyType {
     timestamp: Date::now()
 };
 
-let response = client.document_index(index("myindex"), id(doc.id), doc)
+let doc_id = doc.id;
+let response = client.document_index(index("myindex"), doc)
+                     .id(doc_id)
                      .send()?;
 # Ok(())
 # }

--- a/src/queries/samples/search/src/main.rs
+++ b/src/queries/samples/search/src/main.rs
@@ -73,6 +73,6 @@ fn run() -> Result<(), Box<Error>> {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     run().unwrap()
 }

--- a/tests/run/src/document/delete.rs
+++ b/tests/run/src/document/delete.rs
@@ -34,7 +34,8 @@ impl IntegrationTest for Delete {
     // Index a document, get it, delete it, then try get it again
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
         let index_res = client
-            .document_index(index(INDEX), id(ID), Doc { id: ID })
+            .document_index(index(INDEX), Doc { id: ID })
+            .id(ID)
             .params_fluent(|p| p.url_param("refresh", true))
             .send();
 

--- a/tests/run/src/document/simple_index_get.rs
+++ b/tests/run/src/document/simple_index_get.rs
@@ -44,7 +44,8 @@ impl IntegrationTest for SimpleIndexGet {
     // Index a document, then get it
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
         let index_res = client
-            .document_index(index(INDEX), id(ID), doc())
+            .document_index(index(INDEX), doc())
+            .id(ID)
             .params_fluent(|p| p.url_param("refresh", true))
             .send();
 

--- a/tests/run/src/document/update_with_doc.rs
+++ b/tests/run/src/document/update_with_doc.rs
@@ -43,7 +43,8 @@ impl IntegrationTest for UpdateWithDoc {
     // Execute an update request against that index using a new document
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
         let index_res = client
-            .document_index(index(INDEX), id(ID), doc())
+            .document_index(index(INDEX), doc())
+            .id(ID)
             .params_fluent(|p| p.url_param("refresh", true))
             .send();
 

--- a/tests/run/src/document/update_with_inline_script.rs
+++ b/tests/run/src/document/update_with_inline_script.rs
@@ -38,7 +38,8 @@ impl IntegrationTest for UpdateWithInlineScript {
         let delete_res = client.index_delete(index(INDEX)).send();
 
         let index_res = client
-            .document_index(index(INDEX), id(ID), doc())
+            .document_index(index(INDEX), doc())
+            .id(ID)
             .params_fluent(|p| p.url_param("refresh", true))
             .send();
 

--- a/tests/run/src/document/update_with_script.rs
+++ b/tests/run/src/document/update_with_script.rs
@@ -38,7 +38,8 @@ impl IntegrationTest for UpdateWithScript {
         let delete_res = client.index_delete(index(INDEX)).send();
 
         let index_res = client
-            .document_index(index(INDEX), id(ID), doc())
+            .document_index(index(INDEX), doc())
+            .id(ID)
             .params_fluent(|p| p.url_param("refresh", true))
             .send();
 

--- a/tests/run/src/main.rs
+++ b/tests/run/src/main.rs
@@ -36,7 +36,7 @@ mod build_container;
 mod wait_until_ready;
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let matches = App::new("elastic_integration_tests")
         .arg(

--- a/tests/run/src/search/empty_query.rs
+++ b/tests/run/src/search/empty_query.rs
@@ -29,7 +29,8 @@ impl IntegrationTest for EmptyQuery {
 
         let index_reqs = future::join_all((0..10).into_iter().map(move |i| {
             client
-                .document_index(index(INDEX), id(i), Doc { id: i })
+                .document_index(index(INDEX), Doc { id: i })
+                .id(i)
                 .params_fluent(|p| p.url_param("refresh", true))
                 .send()
         }));

--- a/tests/run/src/search/raw_query_string.rs
+++ b/tests/run/src/search/raw_query_string.rs
@@ -29,7 +29,8 @@ impl IntegrationTest for RawQueryString {
 
         let index_reqs = future::join_all((0..10).into_iter().map(move |i| {
             client
-                .document_index(index(INDEX), id(i), Doc { id: i })
+                .document_index(index(INDEX), Doc { id: i })
+                .id(i)
                 .params_fluent(|p| p.url_param("refresh", true))
                 .send()
         }));


### PR DESCRIPTION
For #308

Make it possible to avoid specifying the id parameter on `document_index` requests. There's a bit of an ergonomic hit for `document_index` if you do want to specify an id, but should be sorted by #301 