### PR TITLE
Ensure async client is send + sync

### DIFF
--- a/src/elastic/src/client/mod.rs
+++ b/src/elastic/src/client/mod.rs
@@ -708,5 +708,8 @@ mod tests {
     fn client_is_send_sync() {
         assert_send::<SyncClient>();
         assert_sync::<SyncClient>();
+
+        assert_send::<AsyncClient>();
+        assert_sync::<AsyncClient>();
     }
 }

--- a/src/elastic/src/client/sender/async.rs
+++ b/src/elastic/src/client/sender/async.rs
@@ -95,7 +95,7 @@ pub struct AsyncSender {
         Arc<
             Fn(
                 &mut AsyncHttpRequest,
-            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>>,
+            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>> + Send + Sync,
         >,
     >,
 }
@@ -329,7 +329,7 @@ pub struct AsyncClientBuilder {
         Arc<
             Fn(
                 &mut AsyncHttpRequest,
-            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>>,
+            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>> + Send + Sync,
         >,
     >,
 }
@@ -524,7 +524,7 @@ impl AsyncClientBuilder {
         pre_send: impl Fn(
                 &mut AsyncHttpRequest,
             ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>>
-            + 'static,
+            + Send + Sync + 'static,
     ) -> Self {
         self.pre_send = Some(Arc::new(pre_send));
 


### PR DESCRIPTION
Fixes #321 

Require a pre-send function to be `Send + Sync` so that the `AsyncClient` is `Send + Sync` again.