### PR TITLE
Prepare for 0.21.0-pre.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Add `elastic` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-elastic = "0.21.0-pre.1"
-elastic_derive = "0.21.0-pre.1"
+elastic = "0.21.0-pre.2"
+elastic_derive = "0.21.0-pre.2"
 serde_json = "1"
 ```
 

--- a/examples/account_sample/Cargo.toml
+++ b/examples/account_sample/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 publish = false
 
 [dependencies]
-elastic = { version = "~0.21.0-pre.1", path = "../../src/elastic" }
-elastic_derive = { version = "~0.21.0-pre.1", path = "../../src/elastic_derive" }
+elastic = { version = "~0.21.0-pre.2", path = "../../src/elastic" }
+elastic_derive = { version = "~0.21.0-pre.2", path = "../../src/elastic_derive" }
 
-quick-error = "*"
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
+quick-error = "~1"
+serde = "~1"
+serde_json = "~1"
+serde_derive = "~1"

--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT/Apache-2.0"
 keywords = ["elasticsearch", "search"]
@@ -31,12 +31,12 @@ tokio-threadpool = "~0.1"
 fluent_builder = "~0.5"
 crossbeam-channel = "~0.3"
 
-elastic_requests = { version = "~0.21.0-pre.1", path = "../requests" }
-elastic_responses = { version = "~0.21.0-pre.1", path = "../responses" }
-elastic_types = { version = "~0.21.0-pre.1", path = "../types" }
+elastic_requests = { version = "~0.21.0-pre.2", path = "../requests" }
+elastic_responses = { version = "~0.21.0-pre.2", path = "../responses" }
+elastic_types = { version = "~0.21.0-pre.2", path = "../types" }
 
 [dev-dependencies]
 json_str = "~0.5"
 serde_derive = "~1"
-elastic_derive = { version = "~0.21.0-pre.1", path = "../elastic_derive" }
+elastic_derive = { version = "~0.21.0-pre.2", path = "../elastic_derive" }
 env_logger = "~0.6"

--- a/src/elastic/src/client/requests/bulk/stream.rs
+++ b/src/elastic/src/client/requests/bulk/stream.rs
@@ -294,7 +294,9 @@ where
             BulkSenderInFlight::ReadyToSend => {
                 match self.timeout.poll() {
                     // If the timeout hasn't expired and the body isn't full then we're not ready
-                    Ok(Async::NotReady) if !self.body.is_full() && !self.body.is_empty() => return Ok(Async::NotReady),
+                    Ok(Async::NotReady) if !self.body.is_full() && !self.body.is_empty() => {
+                        return Ok(Async::NotReady);
+                    }
                     // Continue
                     Ok(Async::NotReady) => (),
                     // Restart the expired timer

--- a/src/elastic/src/client/sender/async.rs
+++ b/src/elastic/src/client/sender/async.rs
@@ -94,8 +94,10 @@ pub struct AsyncSender {
     pre_send: Option<
         Arc<
             Fn(
-                &mut AsyncHttpRequest,
-            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>> + Send + Sync,
+                    &mut AsyncHttpRequest,
+                ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>>
+                + Send
+                + Sync,
         >,
     >,
 }
@@ -328,8 +330,10 @@ pub struct AsyncClientBuilder {
     pre_send: Option<
         Arc<
             Fn(
-                &mut AsyncHttpRequest,
-            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>> + Send + Sync,
+                    &mut AsyncHttpRequest,
+                ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>>
+                + Send
+                + Sync,
         >,
     >,
 }
@@ -524,7 +528,9 @@ impl AsyncClientBuilder {
         pre_send: impl Fn(
                 &mut AsyncHttpRequest,
             ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>>>
-            + Send + Sync + 'static,
+            + Send
+            + Sync
+            + 'static,
     ) -> Self {
         self.pre_send = Some(Arc::new(pre_send));
 

--- a/src/elastic/src/lib.rs
+++ b/src/elastic/src/lib.rs
@@ -25,16 +25,16 @@ To get stated, add `elastic` to your `Cargo.toml`:
 
 ```ignore
 [dependencies]
-elastic = "*"
-elastic_derive = "*"
+elastic = "~0.21.0-pre.2"
+elastic_derive = "~0.21.0-pre.2"
 ```
 
 The following optional dependencies may also be useful:
 
 ```ignore
-serde = "*"
-serde_json = "*"
-serde_derive = "*"
+serde = "~1"
+serde_json = "~1"
+serde_derive = "~1"
 ```
 
 Then reference in your crate root:

--- a/src/elastic_derive/Cargo.toml
+++ b/src/elastic_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_derive"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT/Apache-2.0"
 description = "Compile-time code generation for Elasticsearch type implementations."
@@ -11,6 +11,6 @@ name = "elastic_derive"
 proc-macro = true
 
 [dependencies]
-elastic_types_derive_internals = { version = "~0.21.0-pre.1", path = "../types_derive_internals" }
+elastic_types_derive_internals = { version = "~0.21.0-pre.2", path = "../types_derive_internals" }
 syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
 quote = "~0.3.0"

--- a/src/requests/Cargo.toml
+++ b/src/requests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_requests"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT/Apache-2.0"
 description = "Code generated request types for the Elasticsearch REST API."

--- a/src/responses/Cargo.toml
+++ b/src/responses/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Stephan Buys <stephan.buys@panoptix.co.za>", "Ashley Mannix <ashleymannix@live.com.au>"]
 name = "elastic_responses"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 license = "MIT/Apache-2.0"
 description = "Parses search results from Elasticsearch and presents results using convenient iterators."
 documentation = "https://docs.rs/elastic_responses"

--- a/src/responses/src/lib.rs
+++ b/src/responses/src/lib.rs
@@ -16,7 +16,7 @@ Add `elastic_responses` to your `Cargo.toml`:
 
 ```text
 [dependencies]
-elastic_responses = "*"
+elastic_responses = "~0.21.0-pre.2"
 ```
 
 Use the [`parse`][parse] function to deserialise a http response to a `Result<T, ApiError>` for some

--- a/src/types/Cargo.toml
+++ b/src/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT/Apache-2.0"
 description = "A strongly-typed implementation of Elasticsearch core types and Mapping API."
@@ -16,7 +16,7 @@ geohash = "~0.4.0"
 geojson = "~0.9.0"
 serde_derive = "~1"
 # TODO: Move this to a `dev-dependency`
-elastic_types_derive = { version = "~0.21.0-pre.1", path = "../types_derive" }
+elastic_types_derive = { version = "~0.21.0-pre.2", path = "../types_derive" }
 
 [dev-dependencies]
 json_str = "^0.*"

--- a/src/types/src/lib.rs
+++ b/src/types/src/lib.rs
@@ -24,8 +24,8 @@ To get started, add `elastic_types` and `elastic_types_derive` to your `Cargo.to
 
 ```ignore
 [dependencies]
-elastic_types = version = "~0.21.0-pre.1"
-elastic_types_derive = "*"
+elastic_types = version = "~0.21.0-pre.2"
+elastic_types_derive = "~0.21.0-pre.2"
 ```
 
 And reference it in your crate root:
@@ -324,8 +324,8 @@ Our `Cargo.toml` specifies the dependencies as above:
 
 ```ignore
 [dependencies]
-elastic_types = "*"
-elastic_types_derive = "*"
+elastic_types = "~0.21.0-pre.2"
+elastic_types_derive = "~0.21.0-pre.2"
 ```
 
 And our `main.rs` contains the following:

--- a/src/types/tests/derive_compile_test/Cargo.toml
+++ b/src/types/tests/derive_compile_test/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 publish = false
 
 [dependencies]
-elastic_types = { version = "~0.21.0-pre.1", path = "../../" }
-elastic_types_derive = { version = "~0.21.0-pre.1", path = "../../../types_derive" }
+elastic_types = { version = "~0.21.0-pre.2", path = "../../" }
+elastic_types_derive = { version = "~0.21.0-pre.2", path = "../../../types_derive" }

--- a/src/types_derive/Cargo.toml
+++ b/src/types_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types_derive"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT/Apache-2.0"
 description = "Compile-time code generation for Elasticsearch type implementations."
@@ -11,6 +11,6 @@ name = "elastic_types_derive"
 proc-macro = true
 
 [dependencies]
-elastic_types_derive_internals = { version = "~0.21.0-pre.1", path = "../types_derive_internals" }
+elastic_types_derive_internals = { version = "~0.21.0-pre.2", path = "../types_derive_internals" }
 syn = { version = "~0.11.0", features = ["full"] }
 quote = "~0.3.0"

--- a/src/types_derive_internals/Cargo.toml
+++ b/src/types_derive_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_types_derive_internals"
-version = "0.21.0-pre.1"
+version = "0.21.0-pre.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "MIT/Apache-2.0"
 description = "Codegen internals for elastic_types."

--- a/tests/run/Cargo.toml
+++ b/tests/run/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 publish = false
 
 [dependencies]
-elastic = { version = "~0.21.0-pre.1", path = "../../src/elastic" }
-elastic_derive = { version = "~0.21.0-pre.1", path = "../../src/elastic_derive" }
+elastic = { version = "~0.21.0-pre.2", path = "../../src/elastic" }
+elastic_derive = { version = "~0.21.0-pre.2", path = "../../src/elastic_derive" }
 
 serde = "~1"
 serde_derive = "~1"

--- a/tests/run/src/bulk/index_get.rs
+++ b/tests/run/src/bulk/index_get.rs
@@ -27,18 +27,24 @@ impl IntegrationTest for IndexGet {
 
     // Ensure the index doesn't exist
     fn prepare(&self, client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
-        let delete_res = client.index(Doc::static_index()).delete().send().map(|_| ());
+        let delete_res = client
+            .index(Doc::static_index())
+            .delete()
+            .send()
+            .map(|_| ());
 
         Box::new(delete_res)
     }
 
     // Index some bulk documents
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
-        let ops = (0..10).into_iter().map(|i| bulk().index(Doc {
-            id: i.to_string(),
-            title: "A document title".to_owned(),
-            timestamp: Date::build(2017, 03, 24, 13, 44, 0, 0),
-        }));
+        let ops = (0..10).into_iter().map(|i| {
+            bulk().index(Doc {
+                id: i.to_string(),
+                title: "A document title".to_owned(),
+                timestamp: Date::build(2017, 03, 24, 13, 44, 0, 0),
+            })
+        });
 
         let bulk_res = client
             .bulk()

--- a/tests/run/src/bulk/mod.rs
+++ b/tests/run/src/bulk/mod.rs
@@ -4,12 +4,12 @@ use run_tests::{
 };
 
 mod delete;
-mod index_get;
 mod index_create;
+mod index_get;
 mod stream;
 mod stream_tiny_size_limit;
-mod stream_zero_size_limit;
 mod stream_tiny_timeout;
+mod stream_zero_size_limit;
 
 pub fn tests() -> Vec<Test> {
     vec![

--- a/tests/run/src/bulk/stream_tiny_timeout.rs
+++ b/tests/run/src/bulk/stream_tiny_timeout.rs
@@ -1,9 +1,14 @@
-use std::time::Duration;
+use elastic::client::responses::bulk::OkItem;
 use elastic::error::Error;
 use elastic::prelude::*;
-use elastic::client::responses::bulk::OkItem;
-use futures::{stream, Stream, Sink, Future};
+use futures::{
+    stream,
+    Future,
+    Sink,
+    Stream,
+};
 use run_tests::IntegrationTest;
+use std::time::Duration;
 
 #[derive(Debug, Clone, Copy)]
 pub struct BulkStreamTinyTimeout;
@@ -42,14 +47,16 @@ impl IntegrationTest for BulkStreamTinyTimeout {
             .bulk_stream()
             .timeout(Duration::from_nanos(1))
             .build();
-        
-        let ops = (0..20).into_iter().map(|i| bulk().index(Doc { id: i.to_string() }));
+
+        let ops = (0..20)
+            .into_iter()
+            .map(|i| bulk().index(Doc { id: i.to_string() }));
 
         let req_future = bulk_stream.send_all(stream::iter_ok(ops));
 
         let res_future = bulk_responses.fold(Vec::new(), |mut ops, bulk| {
             ops.extend(bulk.into_iter().filter_map(Result::ok));
-            
+
             Ok(ops)
         });
 

--- a/tests/run/src/bulk/stream_zero_size_limit.rs
+++ b/tests/run/src/bulk/stream_zero_size_limit.rs
@@ -1,7 +1,12 @@
+use elastic::client::responses::bulk::OkItem;
 use elastic::error::Error;
 use elastic::prelude::*;
-use elastic::client::responses::bulk::OkItem;
-use futures::{stream, Stream, Sink, Future};
+use futures::{
+    stream,
+    Future,
+    Sink,
+    Stream,
+};
 use run_tests::IntegrationTest;
 
 #[derive(Debug, Clone, Copy)]
@@ -37,18 +42,17 @@ impl IntegrationTest for BulkStreamZeroSize {
 
     // Stream some bulk operations
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
-        let (bulk_stream, bulk_responses) = client
-            .bulk_stream()
-            .body_size_bytes(0)
-            .build();
-        
-        let ops = (0..20).into_iter().map(|i| bulk().index(Doc { id: i.to_string() }));
+        let (bulk_stream, bulk_responses) = client.bulk_stream().body_size_bytes(0).build();
+
+        let ops = (0..20)
+            .into_iter()
+            .map(|i| bulk().index(Doc { id: i.to_string() }));
 
         let req_future = bulk_stream.send_all(stream::iter_ok(ops));
 
         let res_future = bulk_responses.fold(Vec::new(), |mut ops, bulk| {
             ops.extend(bulk.into_iter().filter_map(Result::ok));
-            
+
             Ok(ops)
         });
 

--- a/tests/run/src/document/simple_mapping.rs
+++ b/tests/run/src/document/simple_mapping.rs
@@ -39,19 +39,27 @@ impl IntegrationTest for SimpleMapping {
 
     // Put the document mapping, then get it back from Elasticsearch
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
-        let create_index = client.index(Doc::static_index()).create().send().map(|_| ());
+        let create_index = client
+            .index(Doc::static_index())
+            .create()
+            .send()
+            .map(|_| ());
 
-        let put_mapping = client
-            .document::<Doc>()
-            .put_mapping()
-            .send();
+        let put_mapping = client.document::<Doc>().put_mapping().send();
 
         let get_mapping = client
-            .request(IndicesGetMappingRequest::for_index_ty(Doc::static_index(), Doc::static_ty()))
+            .request(IndicesGetMappingRequest::for_index_ty(
+                Doc::static_index(),
+                Doc::static_ty(),
+            ))
             .send()
             .and_then(|res| res.into_response::<Value>());
 
-        Box::new(create_index.and_then(|_| put_mapping).and_then(|_| get_mapping))
+        Box::new(
+            create_index
+                .and_then(|_| put_mapping)
+                .and_then(|_| get_mapping),
+        )
     }
 
     // Ensure the response contains the expected document


### PR DESCRIPTION
Fixes up a bug with `bulk().index(doc)` where we'll send invalid JSON.