### PR TITLE
Add allow(missing_docs) attribute to generated mapping_definitions code

### DIFF
--- a/src/types_derive_internals/src/elastic_type/mod.rs
+++ b/src/types_derive_internals/src/elastic_type/mod.rs
@@ -64,6 +64,7 @@ pub fn expand_derive(
     let mapping_impl_block = &mapping.impl_block;
 
     Ok(vec![quote!(
+        #[allow(missing_docs)]
         #mapping_definition
 
         #[allow(non_upper_case_globals, dead_code, unused_variables)]


### PR DESCRIPTION
The code generated for mapping_definitions was causing linting issues when using the ElasticType derive attribute.