### PR TITLE
Make DEFAULT_DOC_TYPE used throughout client and generated code

### DIFF
--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -34,7 +34,7 @@ use types::document::{
     StaticIndex,
     StaticType,
 };
-use types::DEFAULT_TYPE;
+use types::document::DEFAULT_DOC_TYPE;
 
 /**
 A [delete document request][docs-delete] builder that can be configured before sending.
@@ -181,7 +181,7 @@ where
             self.inner,
             DeleteRequestInner {
                 index: index.into(),
-                ty: DEFAULT_TYPE.into(),
+                ty: DEFAULT_DOC_TYPE.into(),
                 id: id.into(),
                 _marker: PhantomData,
             },

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -35,7 +35,7 @@ use types::document::{
     StaticIndex,
     StaticType,
 };
-use types::DEFAULT_TYPE;
+use types::document::DEFAULT_DOC_TYPE;
 
 /**
 A [get document request][docs-get] builder that can be configured before sending.
@@ -176,7 +176,7 @@ where
             self.inner,
             GetRequestInner {
                 index: index.into(),
-                ty: DEFAULT_TYPE.into(),
+                ty: DEFAULT_DOC_TYPE.into(),
                 id: id.into(),
                 _marker: PhantomData,
             },

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -33,8 +33,7 @@ use error::{
     Error,
     Result,
 };
-use types::document::DocumentType;
-use types::DEFAULT_TYPE;
+use types::document::{DocumentType, DEFAULT_DOC_TYPE};
 
 /**
 An [index request][docs-index] builder that can be configured before sending.
@@ -198,7 +197,7 @@ where
             self.inner,
             IndexRequestInner {
                 index: index.into(),
-                ty: DEFAULT_TYPE.into(),
+                ty: DEFAULT_DOC_TYPE.into(),
                 id: None,
                 doc: doc,
             },

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -35,8 +35,8 @@ use types::document::{
     DocumentType,
     StaticIndex,
     StaticType,
+    DEFAULT_DOC_TYPE,
 };
-use types::DEFAULT_TYPE;
 
 pub use client::requests::common::{
     DefaultParams,
@@ -287,7 +287,7 @@ where
             self.inner,
             UpdateRequestInner {
                 index: index.into(),
-                ty: DEFAULT_TYPE.into(),
+                ty: DEFAULT_DOC_TYPE.into(),
                 id: id.into(),
                 body: Doc::empty(),
                 _marker: PhantomData,

--- a/src/elastic/src/types.rs
+++ b/src/elastic/src/types.rs
@@ -275,7 +275,5 @@ pub use elastic_types::{
     string,
 };
 
-pub(crate) const DEFAULT_TYPE: &'static str = "doc";
-
 #[doc(hidden)]
 pub use elastic_types::derive;

--- a/src/types/src/derive.rs
+++ b/src/types/src/derive.rs
@@ -34,6 +34,7 @@ pub use document::mapping::{
     PropertiesMapping,
 };
 pub use document::{
+    DEFAULT_DOC_TYPE,
     DocumentType,
     StaticIndex,
     StaticType,

--- a/src/types/src/document/impls.rs
+++ b/src/types/src/document/impls.rs
@@ -9,6 +9,11 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 
 /**
+The default name for document types in a single document index.
+*/
+pub const DEFAULT_DOC_TYPE: &'static str = "doc";
+
+/**
 An indexable Elasticsearch type.
 
 This trait is implemented for the type being mapped, rather than the mapping

--- a/src/types_derive_internals/src/elastic_type/mod.rs
+++ b/src/types_derive_internals/src/elastic_type/mod.rs
@@ -164,6 +164,7 @@ fn get_doc_ty_impl_block(
 
         // Get the default method blocks for `DocumentType`
         fn get_doc_type_methods(
+            crate_root: &Tokens,
             item: &syn::MacroInput,
             fields: &[(syn::Ident, &syn::Field)],
         ) -> ElasticMetadataMethods {
@@ -190,7 +191,7 @@ fn get_doc_ty_impl_block(
                 match get_method_from_struct(item, "ty") {
                     Some(MethodFromStruct::Literal(name)) => (name, true),
                     Some(MethodFromStruct::Expr(method)) => (quote!(#method(self)), false),
-                    _ => (quote!("doc"), true),
+                    _ => (quote!(#crate_root::derive::DEFAULT_DOC_TYPE), true),
                 }
             };
 
@@ -224,7 +225,7 @@ fn get_doc_ty_impl_block(
             ref ty,
             ty_is_static,
             ref id,
-        } = get_doc_type_methods(item, fields);
+        } = get_doc_type_methods(crate_root, item, fields);
 
         let doc_ty = &item.ident;
 


### PR DESCRIPTION
For #337 

You'd expect the `DEFAULT_TYPE` constant to be used everywhere we expect the default type for newer Elasticsearch versions, but that isn't actually the case. This PR just moves the constant so it's used everywhere without renaming it just yet.

cc @mwilliammyers 