### PR TITLE
Add more ApiError enum variants

### DIFF
--- a/src/responses/src/error.rs
+++ b/src/responses/src/error.rs
@@ -155,6 +155,11 @@ quick_error! {
             description("action request failed validation")
             display("action request failed validation: '{}'", reason)
         }
+        /** The request body can't be parsed.  */
+        Parsing { reason: String } {
+            description("parsing failed")
+            display("parsing failed: '{}'", reason)
+        }
         #[doc(hidden)]
         __NonExhaustive {}
     }
@@ -232,6 +237,13 @@ impl From<Map<String, Value>> for ParsedApiError {
                 let reason = error_key!(obj[reason]: |v| v.as_str());
 
                 ParsedApiError::Known(ApiError::ActionRequestValidation {
+                    reason: reason.into(),
+                })
+            }
+            "parsing_exception" => {
+                let reason = error_key!(obj[reason]: |v| v.as_str());
+
+                ParsedApiError::Known(ApiError::Parsing {
                     reason: reason.into(),
                 })
             }

--- a/src/responses/src/error.rs
+++ b/src/responses/src/error.rs
@@ -160,6 +160,11 @@ quick_error! {
             description("parsing failed")
             display("parsing failed: '{}'", reason)
         }
+        /** There was an illegal argument in the request.  */
+        IllegalArgument { reason: String } {
+            description("illegal argument")
+            display("illegal argument: '{}'", reason)
+        }
         #[doc(hidden)]
         __NonExhaustive {}
     }
@@ -244,6 +249,13 @@ impl From<Map<String, Value>> for ParsedApiError {
                 let reason = error_key!(obj[reason]: |v| v.as_str());
 
                 ParsedApiError::Known(ApiError::Parsing {
+                    reason: reason.into(),
+                })
+            }
+            "illegal_argument_exception" => {
+                let reason = error_key!(obj[reason]: |v| v.as_str());
+
+                ParsedApiError::Known(ApiError::IllegalArgument {
                     reason: reason.into(),
                 })
             }


### PR DESCRIPTION
I didn't really know what to name the variant... I was torn between making it something less generic than `Parsing` vs. following the convention of sticking to the elasticsearch exception type name (`parsing_exception`).