### PR TITLE
Use rustls for TLS

### DIFF
--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -24,7 +24,7 @@ http = "~0.1"
 serde = "~1"
 serde_json = "~1"
 serde_derive = "~1"
-reqwest = "~0.9"
+reqwest = { version = "~0.9", default-features = false, features = ["rustls-tls"]}
 futures = "~0.1"
 tokio = "~0.1"
 tokio-threadpool = "~0.1"

--- a/src/elastic/src/error.rs
+++ b/src/elastic/src/error.rs
@@ -110,8 +110,8 @@ impl StdError for WrappedError {
         self.0.description()
     }
 
-    fn cause(&self) -> Option<&StdError> {
-        self.0.cause()
+    fn source(&self) -> Option<&(StdError + 'static)> {
+        self.0.source()
     }
 }
 
@@ -126,8 +126,8 @@ impl StdError for ClientError {
         self.inner.description()
     }
 
-    fn cause(&self) -> Option<&StdError> {
-        self.inner.cause()
+    fn source(&self) -> Option<&(StdError + 'static)> {
+        self.inner.source()
     }
 }
 


### PR DESCRIPTION
Closes #336 

Uses [`rustls`](https://github.com/ctz/rustls) instead of OpenSSL, which simplifies portability (and theoretically safety).

Also uses the new `std::error::Error` APIs for #290.