### PR TITLE
Fix bank example

### DIFF
--- a/examples/account_sample/src/model/index.rs
+++ b/examples/account_sample/src/model/index.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 /// Get the name of the bank index.
 pub fn name() -> Index<'static> {
-    "bank-sample".into()
+    "account".into()
 }
 
 /// Get the settings and mappings for the index.

--- a/examples/account_sample/src/model/index.rs
+++ b/examples/account_sample/src/model/index.rs
@@ -21,7 +21,7 @@ pub fn body() -> Value {
                 "filter" : {
                     "email": {
                         "type": "pattern_capture",
-                        "preserve_original": 1,
+                        "preserve_original": true,
                         "patterns": [
                             "([^@]+)",
                             "(\\p{L}+)",


### PR DESCRIPTION
I noticed that the `account_sample` didn't work. My changes fix the issues.

I am not sure where the `Account` type is mapped to the index name `account`. While the origin example uses the index name `bank-sample`, the `Account` type has no information on that.

Can you maybe say something about how the code determines which index to run a query against?