### PR TITLE
Make derive attributes nicer to work with

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-  - TARGET: i686-pc-windows-msvc
-  - TARGET: x86_64-pc-windows-gnu
-  - TARGET: i686-pc-windows-gnu
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe" -FileName "rust-nightly.exe"
   - ps: .\rust-nightly.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null

--- a/examples/account_sample/src/model/account.rs
+++ b/examples/account_sample/src/model/account.rs
@@ -7,10 +7,13 @@
 
 use elastic::prelude::*;
 
+use super::index;
+
 /// Our main model; an account in the bank.
 #[derive(Debug, Serialize, Deserialize, ElasticType)]
-#[elastic(id(expr = "Account::id"))]
+#[elastic(index(expr = "index::name()"))]
 pub struct Account {
+    #[elastic(id(expr = "account_number.to_string()"))]
     pub account_number: i32,
     pub balance: i32,
     pub firstname: FirstName,
@@ -22,12 +25,6 @@ pub struct Account {
     pub email: Email,
     pub city: City,
     pub state: State,
-}
-
-impl Account {
-    fn id(&self) -> String {
-        self.account_number.to_string()
-    }
 }
 
 /// Get the indexed document type name.

--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -29,12 +29,12 @@ use error::{
     Error,
     Result,
 };
+use types::document::DEFAULT_DOC_TYPE;
 use types::document::{
     DocumentType,
     StaticIndex,
     StaticType,
 };
-use types::document::DEFAULT_DOC_TYPE;
 
 /**
 A [delete document request][docs-delete] builder that can be configured before sending.

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -30,12 +30,12 @@ use error::{
     Error,
     Result,
 };
+use types::document::DEFAULT_DOC_TYPE;
 use types::document::{
     DocumentType,
     StaticIndex,
     StaticType,
 };
-use types::document::DEFAULT_DOC_TYPE;
 
 /**
 A [get document request][docs-get] builder that can be configured before sending.

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -33,7 +33,10 @@ use error::{
     Error,
     Result,
 };
-use types::document::{DocumentType, DEFAULT_DOC_TYPE};
+use types::document::{
+    DocumentType,
+    DEFAULT_DOC_TYPE,
+};
 
 /**
 An [index request][docs-index] builder that can be configured before sending.

--- a/src/elastic/src/lib.rs
+++ b/src/elastic/src/lib.rs
@@ -119,8 +119,8 @@ Derive `Serialize`, `Deserialize` and `ElasticType` on your document types:
 # fn run() -> Result<(), Box<::std::error::Error>> {
 #[derive(Serialize, Deserialize, ElasticType)]
 struct MyType {
-    #[elastic(id(expr = "ToString::to_string"))]
-    pub id: String,
+    #[elastic(id(expr = "id.to_string()"))]
+    pub id: i32,
     pub title: String,
     pub timestamp: Date<DefaultDateMapping>
 }

--- a/src/requests/src/genned.rs
+++ b/src/requests/src/genned.rs
@@ -6656,6 +6656,11 @@ pub mod params {
             Alias(Cow::Owned(value))
         }
     }
+    impl<'a> From<Alias<'a>> for Cow<'a, str> {
+        fn from(value: Alias<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for Alias<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6679,6 +6684,11 @@ pub mod params {
     impl<'a> From<String> for Context<'a> {
         fn from(value: String) -> Context<'a> {
             Context(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<Context<'a>> for Cow<'a, str> {
+        fn from(value: Context<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for Context<'a> {
@@ -6706,6 +6716,11 @@ pub mod params {
             Fields(Cow::Owned(value))
         }
     }
+    impl<'a> From<Fields<'a>> for Cow<'a, str> {
+        fn from(value: Fields<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for Fields<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6729,6 +6744,11 @@ pub mod params {
     impl<'a> From<String> for Id<'a> {
         fn from(value: String) -> Id<'a> {
             Id(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<Id<'a>> for Cow<'a, str> {
+        fn from(value: Id<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for Id<'a> {
@@ -6756,6 +6776,11 @@ pub mod params {
             Index(Cow::Owned(value))
         }
     }
+    impl<'a> From<Index<'a>> for Cow<'a, str> {
+        fn from(value: Index<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for Index<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6779,6 +6804,11 @@ pub mod params {
     impl<'a> From<String> for IndexMetric<'a> {
         fn from(value: String) -> IndexMetric<'a> {
             IndexMetric(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<IndexMetric<'a>> for Cow<'a, str> {
+        fn from(value: IndexMetric<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for IndexMetric<'a> {
@@ -6806,6 +6836,11 @@ pub mod params {
             Metric(Cow::Owned(value))
         }
     }
+    impl<'a> From<Metric<'a>> for Cow<'a, str> {
+        fn from(value: Metric<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for Metric<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6829,6 +6864,11 @@ pub mod params {
     impl<'a> From<String> for Name<'a> {
         fn from(value: String) -> Name<'a> {
             Name(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<Name<'a>> for Cow<'a, str> {
+        fn from(value: Name<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for Name<'a> {
@@ -6856,6 +6896,11 @@ pub mod params {
             NewIndex(Cow::Owned(value))
         }
     }
+    impl<'a> From<NewIndex<'a>> for Cow<'a, str> {
+        fn from(value: NewIndex<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for NewIndex<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6879,6 +6924,11 @@ pub mod params {
     impl<'a> From<String> for NodeId<'a> {
         fn from(value: String) -> NodeId<'a> {
             NodeId(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<NodeId<'a>> for Cow<'a, str> {
+        fn from(value: NodeId<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for NodeId<'a> {
@@ -6906,6 +6956,11 @@ pub mod params {
             Repository(Cow::Owned(value))
         }
     }
+    impl<'a> From<Repository<'a>> for Cow<'a, str> {
+        fn from(value: Repository<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for Repository<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6929,6 +6984,11 @@ pub mod params {
     impl<'a> From<String> for ScrollId<'a> {
         fn from(value: String) -> ScrollId<'a> {
             ScrollId(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<ScrollId<'a>> for Cow<'a, str> {
+        fn from(value: ScrollId<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for ScrollId<'a> {
@@ -6956,6 +7016,11 @@ pub mod params {
             Snapshot(Cow::Owned(value))
         }
     }
+    impl<'a> From<Snapshot<'a>> for Cow<'a, str> {
+        fn from(value: Snapshot<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for Snapshot<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -6979,6 +7044,11 @@ pub mod params {
     impl<'a> From<String> for Target<'a> {
         fn from(value: String) -> Target<'a> {
             Target(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<Target<'a>> for Cow<'a, str> {
+        fn from(value: Target<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for Target<'a> {
@@ -7006,6 +7076,11 @@ pub mod params {
             TaskId(Cow::Owned(value))
         }
     }
+    impl<'a> From<TaskId<'a>> for Cow<'a, str> {
+        fn from(value: TaskId<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for TaskId<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -7031,6 +7106,11 @@ pub mod params {
             ThreadPoolPatterns(Cow::Owned(value))
         }
     }
+    impl<'a> From<ThreadPoolPatterns<'a>> for Cow<'a, str> {
+        fn from(value: ThreadPoolPatterns<'a>) -> Cow<'a, str> {
+            value.0
+        }
+    }
     impl<'a> ::std::ops::Deref for ThreadPoolPatterns<'a> {
         type Target = str;
         fn deref(&self) -> &str {
@@ -7054,6 +7134,11 @@ pub mod params {
     impl<'a> From<String> for Type<'a> {
         fn from(value: String) -> Type<'a> {
             Type(Cow::Owned(value))
+        }
+    }
+    impl<'a> From<Type<'a>> for Cow<'a, str> {
+        fn from(value: Type<'a>) -> Cow<'a, str> {
+            value.0
         }
     }
     impl<'a> ::std::ops::Deref for Type<'a> {

--- a/src/requests_codegen/src/gen/mod.rs
+++ b/src/requests_codegen/src/gen/mod.rs
@@ -169,6 +169,12 @@ pub mod types {
                     }
                 }
 
+                impl <'a> From<#ty> for Cow<'a, str> {
+                    fn from(value: #ty) -> Cow<'a, str> {
+                        value.0
+                    }
+                }
+
                 impl <'a> ::std::ops::Deref for #ty {
                     type Target = str;
 

--- a/src/types/src/derive.rs
+++ b/src/types/src/derive.rs
@@ -34,10 +34,10 @@ pub use document::mapping::{
     PropertiesMapping,
 };
 pub use document::{
-    DEFAULT_DOC_TYPE,
     DocumentType,
     StaticIndex,
     StaticType,
+    DEFAULT_DOC_TYPE,
 };
 
 pub use chrono::format::{

--- a/src/types/src/document/impls.rs
+++ b/src/types/src/document/impls.rs
@@ -470,7 +470,7 @@ mod tests {
     #[elastic(
         index = "renamed_index",
         ty = "renamed_ty",
-        id(expr = "CustomType::id"),
+        id(expr = "self.id()"),
         mapping = "ManualCustomTypeMapping"
     )]
     pub struct CustomType {

--- a/src/types/src/document/mod.rs
+++ b/src/types/src/document/mod.rs
@@ -129,7 +129,7 @@ For index names that depend on document fields, use the `#[elastic(index(expr = 
 # extern crate serde;
 # use elastic_types::prelude::*;
 #[derive(Serialize, ElasticType)]
-#[elastic(index(expr = "MyType::index"))]
+#[elastic(index(expr = "self.index()"))]
 pub struct MyType {
     pub my_date: Date<DefaultDateMapping>,
     pub my_string: String,
@@ -201,7 +201,7 @@ pub struct MyType {
 ```
 
 The field annotated with `#[elastic(id)]` must satisfy `impl Into<Cow<'_, str>>`.
-An id can also be calculated based on an expression function using the `#[elastic(id(expr = "function"))]` attribute:
+An id can also be calculated based on an expression function using the `#[elastic(id(expr = "expression"))]` attribute:
 
 ```
 # #[macro_use]
@@ -215,7 +215,7 @@ An id can also be calculated based on an expression function using the `#[elasti
 # extern crate serde;
 # use elastic_types::prelude::*;
 #[derive(Serialize, ElasticType)]
-#[elastic(id(expr = "MyType::id"))]
+#[elastic(id(expr = "self.id()"))]
 pub struct MyType {
     pub my_id: i32,
     pub my_date: Date<DefaultDateMapping>,
@@ -227,6 +227,31 @@ impl MyType {
     fn id(&self) -> String {
         self.my_id.to_string()
     }
+}
+# fn main() {
+# }
+```
+
+An expression can also be used on fields, where an identifier with the same name as the field can be used:
+
+```
+# #[macro_use]
+# extern crate json_str;
+# #[macro_use]
+# extern crate serde_derive;
+# #[macro_use]
+# extern crate elastic_types_derive;
+# #[macro_use]
+# extern crate elastic_types;
+# extern crate serde;
+# use elastic_types::prelude::*;
+#[derive(Serialize, ElasticType)]
+pub struct MyType {
+    #[elastic(id(expr = "my_id.to_string()"))]
+    pub my_id: i32,
+    pub my_date: Date<DefaultDateMapping>,
+    pub my_string: String,
+    pub my_num: i32
 }
 # fn main() {
 # }

--- a/src/types/tests/derive_compile_test/src/main.rs
+++ b/src/types/tests/derive_compile_test/src/main.rs
@@ -17,7 +17,7 @@ pub struct DerivedDocument1 {
 }
 
 #[derive(ElasticType)]
-#[elastic(index(expr = "DerivedDocument2::index"), ty = "doc")]
+#[elastic(index(expr = "self.index()"), ty = "doc")]
 pub struct DerivedDocument2 {
     #[elastic(id)]
     pub field1: String,
@@ -32,13 +32,13 @@ impl DerivedDocument2 {
 
 #[derive(ElasticType)]
 pub struct DerivedDocument2U32 {
-    #[elastic(id(expr = "ToString::to_string"))]
+    #[elastic(id(expr = "field1.to_string()"))]
     pub field1: i32,
     pub field2: i32,
 }
 
 #[derive(ElasticType)]
-#[elastic(index = "derived_documents", id(expr = "DerivedDocument3::id"))]
+#[elastic(index = "derived_documents", id(expr = "self.id()"))]
 struct DerivedDocument3 {
     pub field1: String,
     pub field2: i32,


### PR DESCRIPTION
For #343 

This is a breaking change to our unreleased document derive attributes so they're proper expressions instead of function paths. That means:

```rust
#[elastic(id(expr = "ToString::to_string"))]
id: i32,
```

becomes:

```rust
#[elastic(id(expr = "id.to_string()"))]
id: i32,
```

We also now derive `From<#ty> for Cow<str>` where `#ty` is a request parameter like `Index`, `Type`, `Id`. That makes it easier to stitch these various APIs together.