### PR TITLE
Fix up invalid doc serialization for bulk_raw

### DIFF
--- a/src/elastic/src/client/requests/bulk/operation.rs
+++ b/src/elastic/src/client/requests/bulk/operation.rs
@@ -300,7 +300,7 @@ impl BulkRawOperation {
         BulkRawOperation { _private: () }
     }
 
-    pub fn index<TDocument>(self, doc: TDocument) -> BulkOperation<Doc<TDocument>> {
+    pub fn index<TDocument>(self, doc: TDocument) -> BulkOperation<TDocument> {
         BulkOperation {
             action: Action::Index,
             header: BulkHeader {
@@ -308,7 +308,7 @@ impl BulkRawOperation {
                 ty: None,
                 id: None,
             },
-            inner: Some(Doc::value(doc)),
+            inner: Some(doc),
         }
     }
 
@@ -360,7 +360,7 @@ impl BulkRawOperation {
         .script_fluent(builder)
     }
 
-    pub fn create<TDocument>(self, doc: TDocument) -> BulkOperation<Doc<TDocument>> {
+    pub fn create<TDocument>(self, doc: TDocument) -> BulkOperation<TDocument> {
         BulkOperation {
             action: Action::Create,
             header: BulkHeader {
@@ -368,7 +368,7 @@ impl BulkRawOperation {
                 ty: None,
                 id: None,
             },
-            inner: Some(Doc::value(doc)),
+            inner: Some(doc),
         }
     }
 

--- a/tests/run/src/bulk/mod.rs
+++ b/tests/run/src/bulk/mod.rs
@@ -6,6 +6,8 @@ use run_tests::{
 mod delete;
 mod index_create;
 mod index_get;
+mod raw_index_create;
+mod raw_index_get;
 mod stream;
 mod stream_tiny_size_limit;
 mod stream_tiny_timeout;
@@ -16,6 +18,8 @@ pub fn tests() -> Vec<Test> {
         Box::new(|client| test(client, delete::Delete)),
         Box::new(|client| test(client, index_get::IndexGet)),
         Box::new(|client| test(client, index_create::IndexCreate)),
+        Box::new(|client| test(client, raw_index_get::RawIndexGet)),
+        Box::new(|client| test(client, raw_index_create::RawIndexCreate)),
         Box::new(|client| test(client, stream::BulkStream)),
         Box::new(|client| test(client, stream_tiny_size_limit::BulkStreamTinySize)),
         Box::new(|client| test(client, stream_zero_size_limit::BulkStreamZeroSize)),

--- a/tests/run/src/bulk/raw_index_create.rs
+++ b/tests/run/src/bulk/raw_index_create.rs
@@ -1,0 +1,63 @@
+use elastic::error::Error;
+use elastic::prelude::*;
+use futures::Future;
+use run_tests::IntegrationTest;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RawIndexCreate;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, ElasticType)]
+pub struct Doc {
+    #[elastic(id)]
+    id: String,
+    title: String,
+    timestamp: Date<DefaultDateMapping>,
+}
+
+const INDEX: &'static str = "raw_bulk_index_create";
+const ID: &'static str = "1";
+
+fn doc() -> Doc {
+    Doc {
+        id: ID.to_owned(),
+        title: "A document title".to_owned(),
+        timestamp: Date::build(2017, 03, 24, 13, 44, 0, 0),
+    }
+}
+
+impl IntegrationTest for RawIndexCreate {
+    type Response = BulkResponse;
+
+    fn kind() -> &'static str {
+        "bulk"
+    }
+    fn name() -> &'static str {
+        "index create"
+    }
+
+    // Ensure the index doesn't exist
+    fn prepare(&self, client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
+        let delete_res = client.index(INDEX).delete().send().map(|_| ());
+
+        Box::new(delete_res)
+    }
+
+    // Index a document, then get it
+    fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
+        let bulk_res = client.bulk().push(bulk_raw()
+            .create(doc())
+            .index(INDEX)
+            .ty(Doc::static_ty())
+            .id(ID))
+            .send();
+
+        Box::new(bulk_res)
+    }
+
+    // Ensure the response contains the expected document
+    fn assert_ok(&self, res: &Self::Response) -> bool {
+        let created = res.iter().next().unwrap().unwrap();
+
+        created.action() == BulkAction::Create && created.created()
+    }
+}


### PR DESCRIPTION
Fixes #346 

We did this in #333 for `DocumentType`s, but missed the raw ones.