### PR TITLE
Fixes broken links in search documentation.

### DIFF
--- a/src/elastic/src/client/requests/search.rs
+++ b/src/elastic/src/client/requests/search.rs
@@ -137,8 +137,8 @@ where
     [builder-methods]: requests/search/type.SearchRequestBuilder.html#builder-methods
     [send-sync]: requests/search/type.SearchRequestBuilder.html#send-synchronously
     [send-async]: requests/search/type.SearchRequestBuilder.html#send-asynchronously
-    [types-mod]: ../../types/index.html
-    [documents-mod]: ../../types/document/index.html
+    [types-mod]: ../types/index.html
+    [documents-mod]: ../types/document/index.html
     [docs-querystring]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
     */
     pub fn search<TDocument>(&self) -> SearchRequestBuilder<TSender, TDocument, DefaultBody>


### PR DESCRIPTION
Fixes the links for `types-mod` and `document-mod` in the search documentation.

I'm new to Rust so I'm not sure if I fixed it all correctly. In particular I noticed that the same links are also here https://github.com/elastic-rs/elastic/blob/master/src/elastic/src/client/requests/search.rs#L213-L214 but I couldn't find where that documentation shows up.