### PR TITLE
Fixes links to DocumentClient methods.

### DIFF
--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -39,13 +39,13 @@ use types::document::{
 /**
 A [delete document request][docs-delete] builder that can be configured before sending.
 
-Call [`Client.document_delete`][Client.document_delete] to get a `DeleteRequestBuilder`.
+Call [`Client.document.delete`][Client.document.delete] to get a `DeleteRequestBuilder`.
 The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was created from.
 
 [docs-delete]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
 [send-sync]: #send-synchronously
 [send-async]: #send-asynchronously
-[Client.document_delete]: ../../struct.Client.html#delete-document
+[Client.document.delete]: ../../struct.DocumentClient.html#delete-document-request
 */
 pub type DeleteRequestBuilder<TSender, TDocument> =
     RequestBuilder<TSender, DeleteRequestInner<TDocument>>;

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -40,13 +40,13 @@ use types::document::{
 /**
 A [get document request][docs-get] builder that can be configured before sending.
 
-Call [`Client.document_get`][Client.document_get] to get a `GetRequestBuilder`.
+Call [`Client.document.get`][Client.document.get] to get a `GetRequestBuilder`.
 The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was created from.
 
 [docs-get]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
 [send-sync]: #send-synchronously
 [send-async]: #send-asynchronously
-[Client.document_get]: ../../struct.Client.html#get-document
+[Client.document.get]: ../../struct.DocumentClient.html#get-document-request
 */
 pub type GetRequestBuilder<TSender, TDocument> =
     RequestBuilder<TSender, GetRequestInner<TDocument>>;

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -41,13 +41,13 @@ use types::document::{
 /**
 An [index request][docs-index] builder that can be configured before sending.
 
-Call [`Client.document_index`][Client.document_index] to get an `IndexRequest`.
+Call [`Client.document.index`][Client.document.index] to get an `IndexRequest`.
 The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was created from.
 
 [docs-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
 [send-sync]: #send-synchronously
 [send-async]: #send-asynchronously
-[Client.document_index]: ../../struct.Client.html#index-document
+[Client.document.index]: ../../struct.DocumentClient.html#index-document-request
 */
 pub type IndexRequestBuilder<TSender, TDocument> =
     RequestBuilder<TSender, IndexRequestInner<TDocument>>;

--- a/src/elastic/src/client/requests/document_put_mapping.rs
+++ b/src/elastic/src/client/requests/document_put_mapping.rs
@@ -39,13 +39,13 @@ use types::document::{
 /**
 A [put mapping request][docs-mapping] builder that can be configured before sending.
 
-Call [`Client.document_put_mapping`][Client.document_put_mapping] to get a `PutMappingRequestBuilder`.
+Call [`Client.document.put_mapping`][Client.document.put_mapping] to get a `PutMappingRequestBuilder`.
 The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was created from.
 
 [docs-mapping]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
 [send-sync]: #send-synchronously
 [send-async]: #send-asynchronously
-[Client.document_put_mapping]: ../../struct.Client.html#put-mapping-request
+[Client.document.put_mapping]: ../../struct.DocumentClient.html#put-mapping-request
 */
 pub type PutMappingRequestBuilder<TSender, TDocument> =
     RequestBuilder<TSender, PutMappingRequestInner<TDocument>>;

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -48,13 +48,13 @@ pub use client::requests::common::{
 /**
 An [update document request][docs-update] builder that can be configured before sending.
 
-Call [`Client.document_update`][Client.document_update] to get an `UpdateRequestBuilder`.
+Call [`Client.document.update`][Client.document.update] to get an `UpdateRequestBuilder`.
 The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was created from.
 
 [docs-update]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
 [send-sync]: #send-synchronously
 [send-async]: #send-asynchronously
-[Client.document_update]: ../../struct.Client.html#update-document
+[Client.document.update]: ../../struct.DocumentClient.html#update-document-request
 */
 pub type UpdateRequestBuilder<TSender, TBody> = RequestBuilder<TSender, UpdateRequestInner<TBody>>;
 


### PR DESCRIPTION
The links for the document related methods were pointing to `Client` to `DocumentClient`. I updated the link.