### PR TITLE
Adds methods to run Elastic sql queries.

### DIFF
--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -34,6 +34,10 @@ pub use self::raw::RawRequestBuilder;
 pub mod search;
 pub use self::search::SearchRequestBuilder;
 
+// Sql requests
+pub mod sql;
+pub use self::sql::SqlRequestBuilder;
+
 // Document requests
 pub mod document_delete;
 pub mod document_get;
@@ -271,6 +275,7 @@ pub mod prelude {
         PutMappingRequestBuilder,
         RawRequestBuilder,
         SearchRequestBuilder,
+        SqlRequestBuilder,
         UpdateRequestBuilder,
     };
 }

--- a/src/elastic/src/client/requests/sql.rs
+++ b/src/elastic/src/client/requests/sql.rs
@@ -1,0 +1,346 @@
+/*!
+Builders for [sql queries][sql].
+
+[sql]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest.html
+*/
+
+use futures::{
+    Future,
+    Poll,
+};
+
+use client::requests::endpoints::SqlQueryRequest;
+use client::requests::raw::RawRequestInner;
+use client::requests::{
+    empty_body,
+    DefaultBody,
+    RequestBuilder,
+};
+use client::responses::SqlResponse;
+use client::sender::{
+    AsyncSender,
+    Sender,
+    SyncSender,
+};
+use client::Client;
+
+use error::{
+    Error,
+    Result,
+};
+
+use serde_json::json;
+
+/**
+A [sql query request][sql] builder that can be configured before sending.
+
+Call [`Client.sql`][Client.sql] to get a `SqlRequestBuilder`.
+The `send` method will either send the request [synchronously][send-sync] or [asynchronously][send-async], depending on the `Client` it was created from.
+
+[sql]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest.html[docs-delete]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
+[send-sync]: #send-synchronously
+[send-async]: #send-asynchronously
+[Client.sql]: ../../struct.Client.html#sql-request
+*/
+pub type SqlRequestBuilder<TSender, TBody> = RequestBuilder<TSender, SqlRequestInner<TBody>>;
+
+#[doc(hidden)]
+pub struct SqlRequestInner<TBody> {
+    body: TBody,
+}
+
+/**
+# Sql request
+*/
+impl<TSender> Client<TSender>
+where
+    TSender: Sender,
+{
+    /**
+    Creates a [`SqlRequestBuilder`][SqlRequestBuilder] with this `Client` that can be configured before sending.
+
+    For more details, see:
+
+    - [builder methods][builder-methods]
+    - [send synchronously][send-sync]
+    - [send asynchronously][send-async]
+
+    # Examples
+
+    Runs a simple [Query String][docs-querystring] query:
+
+    ```no_run
+    # extern crate elastic;
+    # #[macro_use] extern crate serde_json;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = SyncClientBuilder::new().build()?;
+    let response = client.sql()
+                         .body(json!({
+                           "query": "SELECT * FROM library GROUP BY author"
+                         }))
+                         .send()?;
+
+    // Iterate through the hits
+    for row in response.rows() {
+        for column in row {
+            println!("{:?}", column);
+        }
+    }
+    # Ok(())
+    # }
+    ```
+
+    [SqlRequestBuilder]: requests/sql/type.SqlRequestBuilder.html
+    [builder-methods]: requests/sql/type.SqlRequestBuilder.html#builder-methods
+    [send-sync]: requests/sql/type.SqlRequestBuilder.html#send-synchronously
+    [send-async]: requests/sql/type.SqlRequestBuilder.html#send-asynchronously
+    [docs-querystring]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-commands.html
+    */
+    pub fn sql(&self) -> SqlRequestBuilder<TSender, DefaultBody> {
+        RequestBuilder::initial(self.clone(), SqlRequestInner::new(empty_body()))
+    }
+
+    /**
+    Createss a sql query request.
+
+    For more details, see:
+
+    - [send synchronously][send-sync]
+    - [send asynchronously][send-async]
+
+    # Examples
+
+    Runs a simple [Query String][docs-querystring] query:
+
+    ```no_run
+    # extern crate elastic;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = SyncClientBuilder::new().build()?;
+    let response = client.sql_query("SELECT * FROM library GROUP BY author")
+                         .send()?;
+
+    // Iterate through the hits
+    for row in response.rows() {
+        for column in row {
+            println!("{:?}", column);
+        }
+    }
+    # Ok(())
+    # }
+    ```
+
+    [send-sync]: requests/sql/type.SqlRequestBuilder.html#send-synchronously
+    [send-async]: requests/sql/type.SqlRequestBuilder.html#send-asynchronously
+    [docs-querystring]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-commands.html
+    */
+    pub fn sql_query(&self, query: &str) -> SqlRequestBuilder<TSender, serde_json::Value> {
+        self.sql().query(query)
+    }
+}
+
+impl<TBody> SqlRequestInner<TBody> {
+    fn new(body: TBody) -> Self {
+        SqlRequestInner { body: body }
+    }
+
+    fn into_request(self) -> SqlQueryRequest<'static, TBody> {
+        SqlQueryRequest::new(self.body)
+    }
+}
+
+/**
+# Builder methods
+
+Configures a `SqlRequestBuilder` before sending it.
+*/
+impl<TSender, TBody> SqlRequestBuilder<TSender, TBody>
+where
+    TSender: Sender,
+{
+    /**
+    Sets the body for the sql request.
+
+    If no body is specified then an empty query will be used.
+    */
+    pub fn body<TNewBody>(self, body: TNewBody) -> SqlRequestBuilder<TSender, TNewBody>
+    where
+        TNewBody: Into<TSender::Body>,
+    {
+        RequestBuilder::new(
+            self.client,
+            self.params_builder,
+            SqlRequestInner { body: body },
+        )
+    }
+
+    /**
+    Sets the query for the sql request.
+    */
+    pub fn query(self, query: &str) -> SqlRequestBuilder<TSender, serde_json::Value> {
+        RequestBuilder::new(
+            self.client,
+            self.params_builder,
+            SqlRequestInner {
+                body: json!({ "query": query }),
+            },
+        )
+    }
+}
+
+/**
+# Send synchronously
+ */
+impl<TBody> SqlRequestBuilder<SyncSender, TBody>
+where
+    TBody: Into<<SyncSender as Sender>::Body> + 'static,
+{
+    /**
+    Sends a `SqlRequestBuilder` synchronously using a [`SyncClient`][SyncClient].
+
+    This will block the current thread until a response arrives and is deserialised.
+
+    # Examples
+
+    Runs a simple [Query String][docs-querystring] query:
+
+    ```no_run
+    # extern crate elastic;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = SyncClientBuilder::new().build()?;
+    let response = client.sql_query("SELECT * FROM library GROUP BY author")
+                         .send()?;
+
+    // Iterate through the hits
+    for row in response.rows() {
+        for column in row {
+            println!("{:?}", column);
+        }
+    }
+    # Ok(())
+    # }
+    ```
+
+    [SyncClient]: ../../type.SyncClient.html
+    [docs-querystring]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-commands.html
+     */
+    pub fn send(self) -> Result<SqlResponse> {
+        let req = self.inner.into_request();
+
+        RequestBuilder::new(self.client, self.params_builder, RawRequestInner::new(req))
+            .send()?
+            .into_response()
+    }
+}
+
+/**
+# Send asynchronously
+ */
+impl<TBody> SqlRequestBuilder<AsyncSender, TBody>
+where
+    TBody: Into<<AsyncSender as Sender>::Body> + 'static,
+{
+    /**
+    Sends a `SqlRequestBuilder` asynchronously using an [`AsyncClient`][AsyncClient].
+
+    This will return a future that will resolve to the deserialised search response.
+
+    # Examples
+
+    Runs a simple [Query String][docs-querystring] query:
+
+    ```no_run
+    # extern crate tokio;
+    # extern crate futures;
+    # extern crate elastic;
+    # use futures::Future;
+    # use elastic::prelude::*;
+    # fn main() { run().unwrap() }
+    # fn run() -> Result<(), Box<::std::error::Error>> {
+    # let client = AsyncClientBuilder::new().build()?;
+    let future = client.sql_query("SELECT * FROM library GROUP BY author")
+                       .send();
+
+    future.and_then(|response| {
+        // Iterate through the hits
+        for row in response.rows() {
+            for column in row {
+                println!("{:?}", column);
+            }
+        }
+
+        Ok(())
+    });
+    # Ok(())
+    # }
+    ```
+
+    [AsyncClient]: ../../type.AsyncClient.html
+    [docs-querystring]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-commands.html
+    */
+
+    pub fn send(self) -> Pending {
+        let req = self.inner.into_request();
+
+        let res_future =
+            RequestBuilder::new(self.client, self.params_builder, RawRequestInner::new(req))
+                .send()
+                .and_then(|res| res.into_response());
+
+        Pending::new(res_future)
+    }
+}
+
+/** A future returned by calling `send`. */
+pub struct Pending {
+    inner: Box<Future<Item = SqlResponse, Error = Error>>,
+}
+
+impl Pending {
+    fn new<F>(fut: F) -> Self
+    where
+        F: Future<Item = SqlResponse, Error = Error> + 'static,
+    {
+        Pending {
+            inner: Box::new(fut),
+        }
+    }
+}
+
+impl Future for Pending {
+    type Item = SqlResponse;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prelude::*;
+    use serde_json::Value;
+
+    #[test]
+    fn default_request() {
+        let client = SyncClientBuilder::new().build().unwrap();
+
+        let req = client.sql().inner.into_request();
+
+        assert_eq!("/_xpack/sql", req.url.as_ref());
+    }
+
+    #[test]
+    fn specify_body() {
+        let client = SyncClientBuilder::new().build().unwrap();
+
+        let req = client.sql().body("{}").inner.into_request();
+
+        assert_eq!("{}", req.body);
+    }
+}

--- a/src/elastic/src/client/responses/mod.rs
+++ b/src/elastic/src/client/responses/mod.rs
@@ -27,6 +27,7 @@ pub use elastic_responses::{
     PingResponse,
     SearchResponse,
     Shards,
+    SqlResponse,
     UpdateResponse,
 };
 
@@ -49,6 +50,7 @@ pub mod prelude {
         PingResponse,
         SearchResponse,
         Shards,
+        SqlResponse,
         SyncResponseBuilder,
         UpdateResponse,
     };

--- a/src/requests/src/genned.rs
+++ b/src/requests/src/genned.rs
@@ -3400,6 +3400,41 @@ pub mod endpoints {
         }
     }
     #[derive(Debug, PartialEq, Clone)]
+    enum SqlQueryUrlParams {
+        None,
+    }
+    impl SqlQueryUrlParams {
+        pub fn url<'a>(self) -> UrlPath<'a> {
+            match self {
+                SqlQueryUrlParams::None => UrlPath::from("/_xpack/sql"),
+            }
+        }
+    }
+    #[derive(Debug, PartialEq, Clone)]
+    #[doc = "`Post: /_xpack/sql`\n\n[Elasticsearch Documentation](Execute SQL)"]
+    pub struct SqlQueryRequest<'a, B> {
+        pub url: UrlPath<'a>,
+        pub body: B,
+    }
+    impl<'a, B> SqlQueryRequest<'a, B> {
+        #[doc = "Request to: `/_xpack/sql`"]
+        pub fn new(body: B) -> Self {
+            SqlQueryRequest {
+                url: SqlQueryUrlParams::None.url(),
+                body: body,
+            }
+        }
+    }
+    impl<'a, B> Into<Endpoint<'a, B>> for SqlQueryRequest<'a, B> {
+        fn into(self) -> Endpoint<'a, B> {
+            Endpoint {
+                url: self.url,
+                method: Method::POST,
+                body: Some(self.body),
+            }
+        }
+    }
+    #[derive(Debug, PartialEq, Clone)]
     enum UpdateByQueryUrlParams<'a> {
         Index(Index<'a>),
         IndexType(Index<'a>, Type<'a>),

--- a/src/requests_codegen/spec/sql.query.json
+++ b/src/requests_codegen/spec/sql.query.json
@@ -1,0 +1,21 @@
+{
+    "sql.query": {
+      "documentation": "Execute SQL",
+      "methods": [ "POST", "GET" ],
+      "url": {
+        "path": "/_xpack/sql",
+        "paths": [ "/_xpack/sql" ],
+        "parts": {},
+        "params": {
+          "format": {
+            "type" : "string",
+            "description" : "a short version of the Accept header, e.g. json, yaml"
+          }
+        }
+      },
+      "body": {
+        "description" : "Use the `query` element to start a query. Use the `cursor` element to continue a query.",
+        "required" : true
+      }
+    }
+}

--- a/src/responses/src/error.rs
+++ b/src/responses/src/error.rs
@@ -165,6 +165,11 @@ quick_error! {
             description("illegal argument")
             display("illegal argument: '{}'", reason)
         }
+        /** There was a problem with the SQL query. */
+        Verification { reason: String} {
+            description("verification exception")
+            display("verification error: '{}", reason)
+        }
         #[doc(hidden)]
         __NonExhaustive {}
     }
@@ -256,6 +261,13 @@ impl From<Map<String, Value>> for ParsedApiError {
                 let reason = error_key!(obj[reason]: |v| v.as_str());
 
                 ParsedApiError::Known(ApiError::IllegalArgument {
+                    reason: reason.into(),
+                })
+            }
+            "verification_exception" => {
+                let reason = error_key!(obj[reason]: |v| v.as_str());
+
+                ParsedApiError::Known(ApiError::Verification {
                     reason: reason.into(),
                 })
             }

--- a/src/responses/src/lib.rs
+++ b/src/responses/src/lib.rs
@@ -148,6 +148,7 @@ mod get;
 mod index;
 mod ping;
 pub mod search;
+mod sql;
 mod update;
 
 mod indices_exists;
@@ -163,6 +164,7 @@ pub use self::get::*;
 pub use self::index::*;
 pub use self::ping::*;
 pub use self::search::SearchResponse;
+pub use self::sql::*;
 pub use self::update::*;
 
 pub use self::indices_exists::*;

--- a/src/responses/src/sql.rs
+++ b/src/responses/src/sql.rs
@@ -1,0 +1,44 @@
+/*!
+Response types for a [sql request](https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest.html)
+*/
+
+use parsing::IsOkOnSuccess;
+use serde_json::Value;
+
+/** Response for a [sql request][sql-request]. */
+#[derive(Deserialize, Debug)]
+pub struct SqlResponse {
+    columns: Vec<SqlColumn>,
+    rows: Vec<Vec<Value>>,
+}
+
+impl SqlResponse {
+    /** Gets a reference to the result columns. */
+    pub fn columns(&self) -> &Vec<SqlColumn> {
+        &self.columns
+    }
+
+    /** Gets a reference to a vector of rows each a vector of a values. */
+    pub fn rows(&self) -> &Vec<Vec<Value>> {
+        &self.rows
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SqlColumn {
+    name: String,
+    #[serde(rename = "type")]
+    ty: String,
+}
+
+impl SqlColumn {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn ty(&self) -> &str {
+        &self.ty
+    }
+}
+
+impl IsOkOnSuccess for SqlResponse {}

--- a/src/responses/src/sql.rs
+++ b/src/responses/src/sql.rs
@@ -14,7 +14,7 @@ pub struct SqlResponse {
 
 impl SqlResponse {
     /** Gets a reference to the result columns. */
-    pub fn columns(&self) -> &Vec<SqlColumn> {
+    pub fn columns(&self) -> &[SqlColumn] {
         &self.columns
     }
 

--- a/tests/run/src/main.rs
+++ b/tests/run/src/main.rs
@@ -37,6 +37,7 @@ mod document;
 mod index;
 mod run_tests;
 mod search;
+mod sql;
 mod wait_until_ready;
 
 fn main() {

--- a/tests/run/src/run_tests.rs
+++ b/tests/run/src/run_tests.rs
@@ -103,16 +103,19 @@ fn call_future(
     use document;
     use index;
     use search;
+    use sql;
 
     let document_tests = document::tests().into_iter();
     let search_tests = search::tests().into_iter();
     let index_tests = index::tests().into_iter();
     let bulk_tests = bulk::tests().into_iter();
+    let sql_tests = sql::tests().into_iter();
 
     let all_tests = document_tests
         .chain(search_tests)
         .chain(index_tests)
         .chain(bulk_tests)
+        .chain(sql_tests)
         .map(move |t| t(client.clone()));
 
     let test_stream = stream::futures_unordered(all_tests)

--- a/tests/run/src/sql/invalid_query.rs
+++ b/tests/run/src/sql/invalid_query.rs
@@ -1,0 +1,45 @@
+use elastic::error::{
+    ApiError,
+    Error,
+};
+use elastic::prelude::*;
+use futures::Future;
+use run_tests::IntegrationTest;
+
+#[derive(Debug, Clone, Copy)]
+pub struct InvalidQuery;
+
+const INDEX: &'static str = "no_sql_index_idx";
+
+impl IntegrationTest for InvalidQuery {
+    type Response = SqlResponse;
+
+    fn kind() -> &'static str {
+        "sql"
+    }
+    fn name() -> &'static str {
+        "invalid query"
+    }
+
+    // Ensure the index doesn't exist
+    fn prepare(&self, client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
+        let delete_res = client.index(INDEX).delete().send().map(|_| ());
+
+        Box::new(delete_res)
+    }
+
+    // Execute a search request against that index
+    fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
+        let res = client.sql_query(&format!("select * from {}", INDEX)).send();
+
+        Box::new(res)
+    }
+
+    // Ensure a `Parsing` error is returned
+    fn assert_err(&self, err: &Error) -> bool {
+        match *err {
+            Error::Api(ApiError::Verification { .. }) => true,
+            _ => false,
+        }
+    }
+}

--- a/tests/run/src/sql/invalid_syntax.rs
+++ b/tests/run/src/sql/invalid_syntax.rs
@@ -1,0 +1,44 @@
+use elastic::error::{
+    ApiError,
+    Error,
+};
+use elastic::prelude::*;
+use futures::{
+    future,
+    Future,
+};
+use run_tests::IntegrationTest;
+
+#[derive(Debug, Clone, Copy)]
+pub struct InvalidSyntax;
+
+impl IntegrationTest for InvalidSyntax {
+    type Response = SqlResponse;
+
+    fn kind() -> &'static str {
+        "sql"
+    }
+    fn name() -> &'static str {
+        "invalid syntax"
+    }
+
+    // Ensure the index doesn't exist
+    fn prepare(&self, _client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
+        Box::new(future::ok(()))
+    }
+
+    // Execute a search request against that index
+    fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
+        let res = client.sql_query("select").send();
+
+        Box::new(res)
+    }
+
+    // Ensure a `Parsing` error is returned
+    fn assert_err(&self, err: &Error) -> bool {
+        match *err {
+            Error::Api(ApiError::Parsing { .. }) => true,
+            _ => false,
+        }
+    }
+}

--- a/tests/run/src/sql/mod.rs
+++ b/tests/run/src/sql/mod.rs
@@ -1,0 +1,16 @@
+use run_tests::{
+    test,
+    Test,
+};
+
+mod invalid_query;
+mod invalid_syntax;
+mod select_all;
+
+pub fn tests() -> Vec<Test> {
+    vec![
+        Box::new(|client| test(client, select_all::SelectAll)),
+        Box::new(|client| test(client, invalid_syntax::InvalidSyntax)),
+        Box::new(|client| test(client, invalid_query::InvalidQuery)),
+    ]
+}

--- a/tests/run/src/sql/select_all.rs
+++ b/tests/run/src/sql/select_all.rs
@@ -1,0 +1,75 @@
+use elastic::error::Error;
+use elastic::prelude::*;
+use futures::{
+    future,
+    Future,
+};
+use run_tests::IntegrationTest;
+
+#[derive(Debug, Clone, Copy)]
+pub struct SelectAll;
+
+#[derive(Debug, Serialize, Deserialize, ElasticType)]
+#[elastic(index = "sql_select_all_idx")]
+pub struct Doc {
+    #[elastic(id(expr = "id.to_string()"))]
+    id: i32,
+    field1: String,
+}
+
+fn doc(i: i32) -> Doc {
+    Doc {
+        id: i,
+        field1: "field1".to_owned(),
+    }
+}
+
+impl IntegrationTest for SelectAll {
+    type Response = SqlResponse;
+
+    fn kind() -> &'static str {
+        "sql"
+    }
+    fn name() -> &'static str {
+        "select all documents"
+    }
+
+    // Ensure the index doesn't exist
+    fn prepare(&self, client: AsyncClient) -> Box<Future<Item = (), Error = Error>> {
+        let delete_res = client.index(Doc::static_index()).delete().send();
+
+        let index_reqs = future::join_all((0..10).into_iter().map(move |i| {
+            client
+                .document()
+                .index(doc(i))
+                .params_fluent(|p| p.url_param("refresh", true))
+                .send()
+        }));
+
+        Box::new(delete_res.then(|_| index_reqs.map(|_| ())))
+    }
+
+    // Execute a search request against that index
+    fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
+        let res = client
+            .sql_query(&format!("select * from {}", Doc::static_index()))
+            .send();
+
+        Box::new(res)
+    }
+
+    // Ensure the response contains documents
+    fn assert_ok(&self, res: &Self::Response) -> bool {
+        let correct_columns = vec!["id", "field1"].sort()
+            == res
+                .columns()
+                .iter()
+                .map(|c| c.name())
+                .collect::<Vec<&str>>()
+                .sort();
+
+        let correct_length = res.rows().len() == 10;
+
+        correct_columns && correct_length
+    }
+}


### PR DESCRIPTION
I would like to add support for [Elastic SQL queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-sql.html). 

I haven't done the integration tests yet but was hoping to get some feedback on the approach first.