### PR TITLE
exposed ES bulk API error as a raw JSON

### DIFF
--- a/src/responses/src/bulk.rs
+++ b/src/responses/src/bulk.rs
@@ -515,6 +515,9 @@ impl<TIndex, TType, TId> ErrorItem<TIndex, TType, TId> {
     pub fn id(&self) -> &TId {
         &self.id
     }
+
+    /** Raw error JSON. */
+    pub fn err(&self) -> &BulkError { &self.err }
 }
 
 impl<TIndex, TType, TId> fmt::Display for ErrorItem<TIndex, TType, TId>


### PR DESCRIPTION
It's useful for logging. Also, I use the error JSON to determine if the error is temporary or permanent.