### PR TITLE
Added mapping for HashSet collection

### DIFF
--- a/src/types/src/document/impls.rs
+++ b/src/types/src/document/impls.rs
@@ -427,6 +427,7 @@ mod tests {
         Value,
     };
     use std::borrow::Cow;
+    use std::collections::HashSet;
 
     // Make sure we can derive with no `uses`.
     pub mod no_prelude {
@@ -501,6 +502,7 @@ mod tests {
         pub field4: Value,
         pub field5: Option<SimpleNestedType>,
         pub field6: Value,
+        pub field7: HashSet<String>,
     }
 
     #[derive(Serialize, ElasticType)]
@@ -672,6 +674,15 @@ mod tests {
                 },
                 "field6": {
                     "type": "nested"
+                },
+                "field7": {
+                    "type": "text",
+                    "fields": {
+                        "keyword":{
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
                 }
             }
         });

--- a/src/types/src/private/impls.rs
+++ b/src/types/src/private/impls.rs
@@ -6,6 +6,7 @@ use serde::{
 use std::collections::{
     BTreeMap,
     HashMap,
+    HashSet,
 };
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -112,6 +113,13 @@ where
 }
 
 impl<TField, TMapping, TPivot> WrappedFieldType<TMapping, TPivot> for Vec<TField>
+where
+    TField: FieldType<TMapping, TPivot>,
+    TMapping: FieldMapping<TPivot>,
+{
+}
+
+impl<TField, TMapping, TPivot> WrappedFieldType<TMapping, TPivot> for HashSet<TField>
 where
     TField: FieldType<TMapping, TPivot>,
     TMapping: FieldMapping<TPivot>,


### PR DESCRIPTION
Hi,
this adds a mapping for the `std::collections::HashSet` with the same logic as a plain `Vec`