### PR TITLE
Make requests impl Send

### DIFF
--- a/examples/account_sample/src/main.rs
+++ b/examples/account_sample/src/main.rs
@@ -16,12 +16,14 @@ extern crate serde_json;
 pub mod model;
 pub mod ops;
 
-use ops::commands::{
-    EnsureBankIndexExists,
-    PutBulkAccounts,
+use ops::{
+    commands::{
+        EnsureBankIndexExists,
+        PutBulkAccounts,
+    },
+    queries::SimpleSearchQuery,
+    Client,
 };
-use ops::queries::SimpleSearchQuery;
-use ops::Client;
 use std::error::Error;
 
 fn run() -> Result<(), Box<Error>> {

--- a/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
+++ b/examples/account_sample/src/ops/commands/ensure_bank_index_exists.rs
@@ -1,6 +1,8 @@
-use elastic::http::StatusCode;
-use elastic::prelude::*;
-use elastic::Error as ResponseError;
+use elastic::{
+    http::StatusCode,
+    prelude::*,
+    Error as ResponseError,
+};
 use ops::Client;
 use serde_json::Error as JsonError;
 use std::io::Error as IoError;

--- a/examples/account_sample/src/ops/commands/mod.rs
+++ b/examples/account_sample/src/ops/commands/mod.rs
@@ -1,5 +1,7 @@
 mod ensure_bank_index_exists;
 mod put_bulk_accounts;
 
-pub use self::ensure_bank_index_exists::EnsureBankIndexExists;
-pub use self::put_bulk_accounts::PutBulkAccounts;
+pub use self::{
+    ensure_bank_index_exists::EnsureBankIndexExists,
+    put_bulk_accounts::PutBulkAccounts,
+};

--- a/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
+++ b/examples/account_sample/src/ops/commands/put_bulk_accounts.rs
@@ -1,17 +1,21 @@
-use elastic::client::responses::bulk::{
-    BulkErrorsResponse,
-    ErrorItem,
+use elastic::{
+    client::responses::bulk::{
+        BulkErrorsResponse,
+        ErrorItem,
+    },
+    http::SyncBody,
+    prelude::*,
+    Error as ResponseError,
 };
-use elastic::http::SyncBody;
-use elastic::prelude::*;
-use elastic::Error as ResponseError;
 use ops::Client;
-use std::fs::File;
-use std::io::{
-    Error as IoError,
-    Result as IoResult,
+use std::{
+    fs::File,
+    io::{
+        Error as IoError,
+        Result as IoResult,
+    },
+    path::Path,
 };
-use std::path::Path;
 
 use model;
 

--- a/examples/account_sample/src/ops/mod.rs
+++ b/examples/account_sample/src/ops/mod.rs
@@ -1,11 +1,13 @@
 pub mod commands;
 pub mod queries;
 
-use elastic::client::{
-    SyncClient,
-    SyncClientBuilder,
+use elastic::{
+    client::{
+        SyncClient,
+        SyncClientBuilder,
+    },
+    error::Result,
 };
-use elastic::error::Result;
 
 /// A wrapper over the `elastic::Client` that we can implement commands
 /// and queries for.

--- a/examples/account_sample/src/ops/queries/simple_search.rs
+++ b/examples/account_sample/src/ops/queries/simple_search.rs
@@ -1,5 +1,7 @@
-use elastic::error::Result;
-use elastic::prelude::*;
+use elastic::{
+    error::Result,
+    prelude::*,
+};
 use ops::Client;
 
 use model::account::Account;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 imports_indent = "Block"
 imports_layout = "Vertical"
+merge_imports = true

--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "~0.9", default-features = false, features = ["rustls-tls"
 futures = "~0.1"
 tokio = "~0.1"
 tokio-threadpool = "~0.1"
-fluent_builder = "~0.5"
+fluent_builder = { version = "~0.6", git = "https://github.com/KodrAus/fluent_builder.git", branch = "feat/sendable-builders" }
 crossbeam-channel = "~0.3"
 
 elastic_requests = { version = "~0.21.0-pre.4", path = "../requests" }

--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -28,7 +28,7 @@ reqwest = { version = "~0.9", default-features = false, features = ["rustls-tls"
 futures = "~0.1"
 tokio = "~0.1"
 tokio-threadpool = "~0.1"
-fluent_builder = { version = "~0.6", git = "https://github.com/KodrAus/fluent_builder.git", branch = "feat/sendable-builders" }
+fluent_builder = "~0.6"
 crossbeam-channel = "~0.3"
 
 elastic_requests = { version = "~0.21.0-pre.4", path = "../requests" }

--- a/src/elastic/examples/bulk_async_stream.rs
+++ b/src/elastic/examples/bulk_async_stream.rs
@@ -21,8 +21,10 @@ use futures::{
     Sink,
     Stream,
 };
-use std::error::Error;
-use std::time::Duration;
+use std::{
+    error::Error,
+    time::Duration,
+};
 
 fn run() -> Result<(), Box<Error>> {
     // A HTTP client and request parameters

--- a/src/elastic/examples/custom_response.rs
+++ b/src/elastic/examples/custom_response.rs
@@ -13,8 +13,10 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
-use elastic::client::responses::parse::*;
-use elastic::prelude::*;
+use elastic::{
+    client::responses::parse::*,
+    prelude::*,
+};
 use serde_json::Value;
 use std::error::Error;
 

--- a/src/elastic/examples/get.rs
+++ b/src/elastic/examples/get.rs
@@ -11,11 +11,13 @@ extern crate elastic;
 extern crate env_logger;
 extern crate serde_json;
 
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use serde_json::Value;
 use std::error::Error as StdError;
 

--- a/src/elastic/examples/pre_send.rs
+++ b/src/elastic/examples/pre_send.rs
@@ -6,14 +6,16 @@ extern crate elastic;
 extern crate env_logger;
 extern crate reqwest;
 
-use elastic::http::{
-    header::{
-        HeaderName,
-        HeaderValue,
+use elastic::{
+    http::{
+        header::{
+            HeaderName,
+            HeaderValue,
+        },
+        SyncHttpRequest,
     },
-    SyncHttpRequest,
+    prelude::*,
 };
-use elastic::prelude::*;
 use std::{
     collections::hash_map::DefaultHasher,
     error::Error,

--- a/src/elastic/examples/raw.rs
+++ b/src/elastic/examples/raw.rs
@@ -9,8 +9,10 @@ extern crate elastic;
 extern crate env_logger;
 
 use elastic::prelude::*;
-use std::error::Error;
-use std::io::Read;
+use std::{
+    error::Error,
+    io::Read,
+};
 
 fn run() -> Result<(), Box<Error>> {
     // A reqwest HTTP client and default parameters.

--- a/src/elastic/examples/typed.rs
+++ b/src/elastic/examples/typed.rs
@@ -21,11 +21,13 @@ extern crate serde_json;
 
 extern crate elastic;
 
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use std::error::Error as StdError;
 
 #[derive(Debug, Serialize, Deserialize, ElasticType)]

--- a/src/elastic/examples/typed_async.rs
+++ b/src/elastic/examples/typed_async.rs
@@ -23,11 +23,13 @@ extern crate tokio;
 
 extern crate elastic;
 
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use futures::{
     Future,
     IntoFuture,

--- a/src/elastic/src/client/mod.rs
+++ b/src/elastic/src/client/mod.rs
@@ -568,10 +568,12 @@ pub use self::sender::{
     SyncClientBuilder,
 };
 
-use self::requests::params::Index;
-use self::sender::{
-    NodeAddresses,
-    Sender,
+use self::{
+    requests::params::Index,
+    sender::{
+        NodeAddresses,
+        Sender,
+    },
 };
 use std::marker::PhantomData;
 
@@ -685,13 +687,13 @@ pub struct IndexClient<TSender> {
 pub mod prelude {
     /*! A glob import for convenience. */
 
-    pub use super::requests::prelude::*;
-    pub use super::responses::prelude::*;
-    pub use super::sender::{
-        PreRequestParams,
-        RequestParams,
-    };
     pub use super::{
+        requests::prelude::*,
+        responses::prelude::*,
+        sender::{
+            PreRequestParams,
+            RequestParams,
+        },
         AsyncClient,
         AsyncClientBuilder,
         SyncClient,

--- a/src/elastic/src/client/requests/bulk/mod.rs
+++ b/src/elastic/src/client/requests/bulk/mod.rs
@@ -4,36 +4,42 @@ Builders for [bulk requests][docs-bulk].
 [docs-bulk]: https://www.elastic.co/guide/en/elasticsearch/reference/current/bulk.html
 */
 
-use std::error::Error as StdError;
-use std::fmt;
-use std::marker::PhantomData;
-use std::time::Duration;
+use std::{
+    error::Error as StdError,
+    fmt,
+    marker::PhantomData,
+    time::Duration,
+};
 
 use futures::{
     Future,
     Poll,
 };
-use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
+use serde::{
+    de::DeserializeOwned,
+    ser::Serialize,
+};
 
-use client::requests::endpoints::BulkRequest;
-use client::requests::params::{
-    Index,
-    Type,
-};
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::parse::IsOk;
-use client::responses::{
-    BulkErrorsResponse,
-    BulkResponse,
-};
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
 use client::{
+    requests::{
+        endpoints::BulkRequest,
+        params::{
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::{
+        parse::IsOk,
+        BulkErrorsResponse,
+        BulkResponse,
+    },
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
     Client,
     RequestParams,
 };
@@ -66,8 +72,10 @@ pub type BulkRequestBuilder<TSender, TBody, TResponse> =
 mod operation;
 mod stream;
 
-pub use self::operation::*;
-pub use self::stream::*;
+pub use self::{
+    operation::*,
+    stream::*,
+};
 
 #[doc(hidden)]
 pub struct BulkRequestInner<TBody, TResponse> {
@@ -865,8 +873,8 @@ impl<TIndex, TType, TId, TNewId> ChangeId<TNewId> for BulkErrorsResponse<TIndex,
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/bulk/operation.rs
+++ b/src/elastic/src/client/requests/bulk/operation.rs
@@ -1,9 +1,11 @@
-use std::io::{
-    self,
-    Write,
+use std::{
+    io::{
+        self,
+        Write,
+    },
+    marker::PhantomData,
+    ops::Deref,
 };
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 use serde::ser::{
     Serialize,
@@ -12,16 +14,18 @@ use serde::ser::{
 };
 use serde_json;
 
-use client::requests::common::{
-    DefaultParams,
-    Doc,
-    Script,
-    ScriptBuilder,
-};
-use client::requests::params::{
-    Id,
-    Index,
-    Type,
+use client::requests::{
+    common::{
+        DefaultParams,
+        Doc,
+        Script,
+        ScriptBuilder,
+    },
+    params::{
+        Id,
+        Index,
+        Type,
+    },
 };
 use types::document::DocumentType;
 

--- a/src/elastic/src/client/requests/bulk/stream.rs
+++ b/src/elastic/src/client/requests/bulk/stream.rs
@@ -1,13 +1,13 @@
-use std::error::Error as StdError;
-use std::io;
-use std::marker::PhantomData;
-use std::time::{
-    Duration,
-    Instant,
-};
 use std::{
+    error::Error as StdError,
     fmt,
+    io,
+    marker::PhantomData,
     mem,
+    time::{
+        Duration,
+        Instant,
+    },
 };
 
 use bytes::{
@@ -28,8 +28,10 @@ use futures::{
     Sink,
     Stream,
 };
-use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
+use serde::{
+    de::DeserializeOwned,
+    ser::Serialize,
+};
 use tokio::timer::Delay;
 
 use super::{
@@ -39,14 +41,16 @@ use super::{
     Pending,
     WrappedBody,
 };
-use client::requests::params::{
-    Index,
-    Type,
-};
-use client::requests::RequestBuilder;
-use client::responses::parse::IsOk;
-use client::sender::AsyncSender;
 use client::{
+    requests::{
+        params::{
+            Index,
+            Type,
+        },
+        RequestBuilder,
+    },
+    responses::parse::IsOk,
+    sender::AsyncSender,
     Client,
     RequestParams,
 };

--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -328,13 +328,13 @@ impl<TDocument> DeleteRequestBuilder<AsyncSender, TDocument> {
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = DeleteResponse, Error = Error>>,
+    inner: Box<Future<Item = DeleteResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = DeleteResponse, Error = Error> + 'static,
+        F: Future<Item = DeleteResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -353,7 +353,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[derive(ElasticType)]
     struct TestDoc {}

--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -10,30 +10,34 @@ use futures::{
 };
 use std::marker::PhantomData;
 
-use client::requests::endpoints::DeleteRequest;
-use client::requests::params::{
-    Id,
-    Index,
-    Type,
+use client::{
+    requests::{
+        endpoints::DeleteRequest,
+        params::{
+            Id,
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::DeleteResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    DocumentClient,
 };
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::DeleteResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::DocumentClient;
 use error::{
     Error,
     Result,
 };
-use types::document::DEFAULT_DOC_TYPE;
 use types::document::{
     DocumentType,
     StaticIndex,
     StaticType,
+    DEFAULT_DOC_TYPE,
 };
 
 /**
@@ -353,8 +357,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -11,30 +11,34 @@ use futures::{
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 
-use client::requests::endpoints::GetRequest;
-use client::requests::params::{
-    Id,
-    Index,
-    Type,
+use client::{
+    requests::{
+        endpoints::GetRequest,
+        params::{
+            Id,
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::GetResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    DocumentClient,
 };
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::GetResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::DocumentClient;
 use error::{
     Error,
     Result,
 };
-use types::document::DEFAULT_DOC_TYPE;
 use types::document::{
     DocumentType,
     StaticIndex,
     StaticType,
+    DEFAULT_DOC_TYPE,
 };
 
 /**
@@ -356,8 +360,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -328,13 +328,13 @@ where
 
 /** A future returned by calling `send`. */
 pub struct Pending<TDocument> {
-    inner: Box<Future<Item = GetResponse<TDocument>, Error = Error>>,
+    inner: Box<Future<Item = GetResponse<TDocument>, Error = Error> + Send>,
 }
 
 impl<TDocument> Pending<TDocument> {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = GetResponse<TDocument>, Error = Error> + 'static,
+        F: Future<Item = GetResponse<TDocument>, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -356,7 +356,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending<TestDoc>>();
+    }
 
     #[derive(Deserialize, ElasticType)]
     struct TestDoc {}

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -13,21 +13,25 @@ use futures::{
 use serde::Serialize;
 use serde_json;
 
-use client::requests::endpoints::IndexRequest;
-use client::requests::params::{
-    Id,
-    Index,
-    Type,
+use client::{
+    requests::{
+        endpoints::IndexRequest,
+        params::{
+            Id,
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::IndexResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    DocumentClient,
 };
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::IndexResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::DocumentClient;
 use error::{
     self,
     Error,
@@ -406,8 +410,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -381,13 +381,13 @@ where
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = IndexResponse, Error = Error>>,
+    inner: Box<Future<Item = IndexResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = IndexResponse, Error = Error> + 'static,
+        F: Future<Item = IndexResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -406,7 +406,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[derive(Serialize, ElasticType)]
     struct TestDoc {}

--- a/src/elastic/src/client/requests/document_put_mapping.rs
+++ b/src/elastic/src/client/requests/document_put_mapping.rs
@@ -11,20 +11,24 @@ use futures::{
 use serde_json;
 use std::marker::PhantomData;
 
-use client::requests::endpoints::IndicesPutMappingRequest;
-use client::requests::params::{
-    Index,
-    Type,
+use client::{
+    requests::{
+        endpoints::IndicesPutMappingRequest,
+        params::{
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::CommandResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    DocumentClient,
 };
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::CommandResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::DocumentClient;
 use error::{
     self,
     Error,
@@ -293,12 +297,12 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use prelude::*;
     use serde_json::{
         self,
         Value,
     };
     use tests::*;
-    use prelude::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/document_put_mapping.rs
+++ b/src/elastic/src/client/requests/document_put_mapping.rs
@@ -268,13 +268,13 @@ where
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = CommandResponse, Error = Error>>,
+    inner: Box<Future<Item = CommandResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = CommandResponse, Error = Error> + 'static,
+        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -293,11 +293,17 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use prelude::*;
     use serde_json::{
         self,
         Value,
     };
+    use tests::*;
+    use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[derive(ElasticType)]
     struct TestDoc {}

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -12,21 +12,25 @@ use serde::ser::Serialize;
 use serde_json;
 use std::marker::PhantomData;
 
-use client::requests::endpoints::UpdateRequest;
-use client::requests::params::{
-    Id,
-    Index,
-    Type,
+use client::{
+    requests::{
+        endpoints::UpdateRequest,
+        params::{
+            Id,
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::UpdateResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    DocumentClient,
 };
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::UpdateResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::DocumentClient;
 use error::{
     self,
     Error,
@@ -748,12 +752,12 @@ impl Future for Pending {
 #[cfg(test)]
 mod tests {
     use super::ScriptBuilder;
+    use prelude::*;
     use serde_json::{
         self,
         Value,
     };
     use tests::*;
-    use prelude::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -722,13 +722,13 @@ where
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = UpdateResponse, Error = Error>>,
+    inner: Box<Future<Item = UpdateResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = UpdateResponse, Error = Error> + 'static,
+        F: Future<Item = UpdateResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -748,11 +748,17 @@ impl Future for Pending {
 #[cfg(test)]
 mod tests {
     use super::ScriptBuilder;
-    use prelude::*;
     use serde_json::{
         self,
         Value,
     };
+    use tests::*;
+    use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[derive(Serialize, ElasticType)]
     struct TestDoc {}

--- a/src/elastic/src/client/requests/index_close.rs
+++ b/src/elastic/src/client/requests/index_close.rs
@@ -178,13 +178,13 @@ impl IndexCloseRequestBuilder<AsyncSender> {
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = CommandResponse, Error = Error>>,
+    inner: Box<Future<Item = CommandResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = CommandResponse, Error = Error> + 'static,
+        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -203,7 +203,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/requests/index_close.rs
+++ b/src/elastic/src/client/requests/index_close.rs
@@ -9,21 +9,23 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::IndicesCloseRequest;
-use client::requests::params::Index;
-use client::requests::raw::RawRequestInner;
-use client::requests::{
-    empty_body,
-    DefaultBody,
-    RequestBuilder,
+use client::{
+    requests::{
+        empty_body,
+        endpoints::IndicesCloseRequest,
+        params::Index,
+        raw::RawRequestInner,
+        DefaultBody,
+        RequestBuilder,
+    },
+    responses::CommandResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    IndexClient,
 };
-use client::responses::CommandResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::IndexClient;
 use error::*;
 
 /**
@@ -203,8 +205,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/index_create.rs
+++ b/src/elastic/src/client/requests/index_create.rs
@@ -9,21 +9,23 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::IndicesCreateRequest;
-use client::requests::params::Index;
-use client::requests::raw::RawRequestInner;
-use client::requests::{
-    empty_body,
-    DefaultBody,
-    RequestBuilder,
+use client::{
+    requests::{
+        empty_body,
+        endpoints::IndicesCreateRequest,
+        params::Index,
+        raw::RawRequestInner,
+        DefaultBody,
+        RequestBuilder,
+    },
+    responses::CommandResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    IndexClient,
 };
-use client::responses::CommandResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::IndexClient;
 use error::*;
 
 /**
@@ -290,8 +292,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/index_create.rs
+++ b/src/elastic/src/client/requests/index_create.rs
@@ -178,7 +178,7 @@ where
 */
 impl<TBody> IndexCreateRequestBuilder<SyncSender, TBody>
 where
-    TBody: Into<<SyncSender as Sender>::Body> + 'static,
+    TBody: Into<<SyncSender as Sender>::Body> + Send + 'static,
 {
     /**
     Send an `IndexCreateRequestBuilder` synchronously using a [`SyncClient`][SyncClient].
@@ -218,7 +218,7 @@ where
 */
 impl<TBody> IndexCreateRequestBuilder<AsyncSender, TBody>
 where
-    TBody: Into<<AsyncSender as Sender>::Body> + 'static,
+    TBody: Into<<AsyncSender as Sender>::Body> + Send + 'static,
 {
     /**
     Send an `IndexCreateRequestBuilder` asynchronously using an [`AsyncClient`][AsyncClient].
@@ -265,13 +265,13 @@ where
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = CommandResponse, Error = Error>>,
+    inner: Box<Future<Item = CommandResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = CommandResponse, Error = Error> + 'static,
+        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -290,7 +290,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/requests/index_delete.rs
+++ b/src/elastic/src/client/requests/index_delete.rs
@@ -174,13 +174,13 @@ impl IndexDeleteRequestBuilder<AsyncSender> {
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = CommandResponse, Error = Error>>,
+    inner: Box<Future<Item = CommandResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = CommandResponse, Error = Error> + 'static,
+        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -199,7 +199,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/requests/index_delete.rs
+++ b/src/elastic/src/client/requests/index_delete.rs
@@ -9,17 +9,21 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::IndicesDeleteRequest;
-use client::requests::params::Index;
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::CommandResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
+use client::{
+    requests::{
+        endpoints::IndicesDeleteRequest,
+        params::Index,
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::CommandResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    IndexClient,
 };
-use client::IndexClient;
 use error::*;
 
 /**
@@ -199,8 +203,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/index_exists.rs
+++ b/src/elastic/src/client/requests/index_exists.rs
@@ -174,13 +174,13 @@ impl IndexExistsRequestBuilder<AsyncSender> {
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = IndicesExistsResponse, Error = Error>>,
+    inner: Box<Future<Item = IndicesExistsResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = IndicesExistsResponse, Error = Error> + 'static,
+        F: Future<Item = IndicesExistsResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -199,7 +199,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/requests/index_exists.rs
+++ b/src/elastic/src/client/requests/index_exists.rs
@@ -9,17 +9,21 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::IndicesExistsRequest;
-use client::requests::params::Index;
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::IndicesExistsResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
+use client::{
+    requests::{
+        endpoints::IndicesExistsRequest,
+        params::Index,
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::IndicesExistsResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    IndexClient,
 };
-use client::IndexClient;
 use error::*;
 
 /**
@@ -199,8 +203,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/index_open.rs
+++ b/src/elastic/src/client/requests/index_open.rs
@@ -9,21 +9,23 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::IndicesOpenRequest;
-use client::requests::params::Index;
-use client::requests::raw::RawRequestInner;
-use client::requests::{
-    empty_body,
-    DefaultBody,
-    RequestBuilder,
+use client::{
+    requests::{
+        empty_body,
+        endpoints::IndicesOpenRequest,
+        params::Index,
+        raw::RawRequestInner,
+        DefaultBody,
+        RequestBuilder,
+    },
+    responses::CommandResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    IndexClient,
 };
-use client::responses::CommandResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::IndexClient;
 use error::*;
 
 /**
@@ -203,8 +205,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/index_open.rs
+++ b/src/elastic/src/client/requests/index_open.rs
@@ -178,13 +178,13 @@ impl IndexOpenRequestBuilder<AsyncSender> {
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = CommandResponse, Error = Error>>,
+    inner: Box<Future<Item = CommandResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = CommandResponse, Error = Error> + 'static,
+        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -203,7 +203,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -8,24 +8,28 @@ use fluent_builder::FluentBuilder;
 use std::sync::Arc;
 use tokio_threadpool::ThreadPool;
 
-use client::sender::{
-    AsyncSender,
-    RequestParams,
-    Sender,
+use client::{
+    sender::{
+        AsyncSender,
+        RequestParams,
+        Sender,
+    },
+    Client,
 };
-use client::Client;
 
-pub use elastic_requests::endpoints;
-pub use elastic_requests::params;
 pub use elastic_requests::{
     empty_body,
+    endpoints,
+    params,
     DefaultBody,
     Endpoint,
     UrlPath,
 };
 
-pub use self::endpoints::*;
-pub use self::params::*;
+pub use self::{
+    endpoints::*,
+    params::*,
+};
 
 pub mod raw;
 pub use self::raw::RawRequestBuilder;
@@ -44,11 +48,13 @@ pub mod document_get;
 pub mod document_index;
 pub mod document_put_mapping;
 pub mod document_update;
-pub use self::document_delete::DeleteRequestBuilder;
-pub use self::document_get::GetRequestBuilder;
-pub use self::document_index::IndexRequestBuilder;
-pub use self::document_put_mapping::PutMappingRequestBuilder;
-pub use self::document_update::UpdateRequestBuilder;
+pub use self::{
+    document_delete::DeleteRequestBuilder,
+    document_get::GetRequestBuilder,
+    document_index::IndexRequestBuilder,
+    document_put_mapping::PutMappingRequestBuilder,
+    document_update::UpdateRequestBuilder,
+};
 
 // Index requests
 pub mod index_close;
@@ -56,17 +62,21 @@ pub mod index_create;
 pub mod index_delete;
 pub mod index_exists;
 pub mod index_open;
-pub use self::index_close::IndexCloseRequestBuilder;
-pub use self::index_create::IndexCreateRequestBuilder;
-pub use self::index_delete::IndexDeleteRequestBuilder;
-pub use self::index_exists::IndexExistsRequestBuilder;
-pub use self::index_open::IndexOpenRequestBuilder;
+pub use self::{
+    index_close::IndexCloseRequestBuilder,
+    index_create::IndexCreateRequestBuilder,
+    index_delete::IndexDeleteRequestBuilder,
+    index_exists::IndexExistsRequestBuilder,
+    index_open::IndexOpenRequestBuilder,
+};
 
 // Misc requests
 pub mod bulk;
 pub mod ping;
-pub use self::bulk::BulkRequestBuilder;
-pub use self::ping::PingRequestBuilder;
+pub use self::{
+    bulk::BulkRequestBuilder,
+    ping::PingRequestBuilder,
+};
 
 pub mod common;
 
@@ -252,8 +262,10 @@ impl<TRequest> RequestBuilder<AsyncSender, TRequest> {
 pub mod prelude {
     /*! A glob import for convenience. */
 
-    pub use super::endpoints::*;
-    pub use super::params::*;
+    pub use super::{
+        endpoints::*,
+        params::*,
+    };
 
     pub use super::bulk::{
         bulk,

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -156,7 +156,7 @@ where
     */
     pub fn params_fluent(
         mut self,
-        builder: impl Fn(RequestParams) -> RequestParams + 'static,
+        builder: impl Fn(RequestParams) -> RequestParams + Send + 'static,
     ) -> Self {
         self.params_builder = self.params_builder.fluent(builder).boxed();
 

--- a/src/elastic/src/client/requests/mod.rs
+++ b/src/elastic/src/client/requests/mod.rs
@@ -4,7 +4,7 @@ Request types for the Elasticsearch REST API.
 This module contains implementation details that are useful if you want to customise the request process, but aren't generally important for sending requests.
 */
 
-use fluent_builder::FluentBuilder;
+use fluent_builder::SharedFluentBuilder;
 use std::sync::Arc;
 use tokio_threadpool::ThreadPool;
 
@@ -96,7 +96,7 @@ where
     TSender: Sender,
 {
     client: Client<TSender>,
-    params_builder: FluentBuilder<RequestParams>,
+    params_builder: SharedFluentBuilder<RequestParams>,
     inner: TRequest,
 }
 
@@ -112,12 +112,12 @@ where
     fn initial(client: Client<TSender>, req: TRequest) -> Self {
         RequestBuilder {
             client: client,
-            params_builder: FluentBuilder::new(),
+            params_builder: SharedFluentBuilder::new(),
             inner: req,
         }
     }
 
-    fn new(client: Client<TSender>, builder: FluentBuilder<RequestParams>, req: TRequest) -> Self {
+    fn new(client: Client<TSender>, builder: SharedFluentBuilder<RequestParams>, req: TRequest) -> Self {
         RequestBuilder {
             client: client,
             params_builder: builder,
@@ -168,7 +168,7 @@ where
         mut self,
         builder: impl Fn(RequestParams) -> RequestParams + Send + 'static,
     ) -> Self {
-        self.params_builder = self.params_builder.fluent(builder).boxed();
+        self.params_builder = self.params_builder.fluent(builder).shared();
 
         self
     }

--- a/src/elastic/src/client/requests/ping.rs
+++ b/src/elastic/src/client/requests/ping.rs
@@ -187,13 +187,13 @@ impl PingRequestBuilder<AsyncSender> {
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = PingResponse, Error = Error>>,
+    inner: Box<Future<Item = PingResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = PingResponse, Error = Error> + 'static,
+        F: Future<Item = PingResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -212,7 +212,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/requests/ping.rs
+++ b/src/elastic/src/client/requests/ping.rs
@@ -7,16 +7,20 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::PingRequest;
-use client::requests::raw::RawRequestInner;
-use client::requests::RequestBuilder;
-use client::responses::PingResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
+use client::{
+    requests::{
+        endpoints::PingRequest,
+        raw::RawRequestInner,
+        RequestBuilder,
+    },
+    responses::PingResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    Client,
 };
-use client::Client;
 use error::{
     Error,
     Result,
@@ -212,8 +216,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/raw.rs
+++ b/src/elastic/src/client/requests/raw.rs
@@ -101,9 +101,9 @@ impl<TSender, TEndpoint, TBody> RawRequestBuilder<TSender, TEndpoint, TBody>
 where
     TSender: Sender,
     TEndpoint: Into<Endpoint<'static, TBody>>,
-    TBody: Into<<TSender>::Body> + 'static,
+    TBody: Into<<TSender>::Body> + Send + 'static,
     NodeAddresses<TSender>: NextParams,
-    <NodeAddresses<TSender> as NextParams>::Params: Into<TSender::Params> + 'static,
+    <NodeAddresses<TSender> as NextParams>::Params: Into<TSender::Params> + Send + 'static,
 {
     /**
     Send a `RawRequestBuilder`.

--- a/src/elastic/src/client/requests/raw.rs
+++ b/src/elastic/src/client/requests/raw.rs
@@ -5,18 +5,20 @@ Builders for raw requests.
 use fluent_builder::TryIntoValue;
 use std::marker::PhantomData;
 
-use client::requests::{
-    Endpoint,
-    RequestBuilder,
+use client::{
+    requests::{
+        Endpoint,
+        RequestBuilder,
+    },
+    sender::{
+        NextParams,
+        NodeAddresses,
+        SendableRequest,
+        SendableRequestParams,
+        Sender,
+    },
+    Client,
 };
-use client::sender::{
-    NextParams,
-    NodeAddresses,
-    SendableRequest,
-    SendableRequestParams,
-    Sender,
-};
-use client::Client;
 
 /**
 A raw request builder that can be configured before sending.

--- a/src/elastic/src/client/requests/search.rs
+++ b/src/elastic/src/client/requests/search.rs
@@ -11,24 +11,24 @@ use futures::{
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 
-use client::requests::endpoints::SearchRequest;
-use client::requests::params::{
-    Index,
-    Type,
-};
-use client::requests::raw::RawRequestInner;
-use client::requests::{
-    empty_body,
-    DefaultBody,
-    RequestBuilder,
-};
-use client::responses::SearchResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
 use client::{
+    requests::{
+        empty_body,
+        endpoints::SearchRequest,
+        params::{
+            Index,
+            Type,
+        },
+        raw::RawRequestInner,
+        DefaultBody,
+        RequestBuilder,
+    },
+    responses::SearchResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
     Client,
     DocumentClient,
 };
@@ -454,8 +454,8 @@ where
 mod tests {
     use serde_json::Value;
 
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/sql.rs
+++ b/src/elastic/src/client/requests/sql.rs
@@ -9,20 +9,22 @@ use futures::{
     Poll,
 };
 
-use client::requests::endpoints::SqlQueryRequest;
-use client::requests::raw::RawRequestInner;
-use client::requests::{
-    empty_body,
-    DefaultBody,
-    RequestBuilder,
+use client::{
+    requests::{
+        empty_body,
+        endpoints::SqlQueryRequest,
+        raw::RawRequestInner,
+        DefaultBody,
+        RequestBuilder,
+    },
+    responses::SqlResponse,
+    sender::{
+        AsyncSender,
+        Sender,
+        SyncSender,
+    },
+    Client,
 };
-use client::responses::SqlResponse;
-use client::sender::{
-    AsyncSender,
-    Sender,
-    SyncSender,
-};
-use client::Client;
 
 use error::{
     Error,
@@ -323,8 +325,8 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
-    use tests::*;
     use prelude::*;
+    use tests::*;
 
     #[test]
     fn is_send() {

--- a/src/elastic/src/client/requests/sql.rs
+++ b/src/elastic/src/client/requests/sql.rs
@@ -196,7 +196,7 @@ where
  */
 impl<TBody> SqlRequestBuilder<SyncSender, TBody>
 where
-    TBody: Into<<SyncSender as Sender>::Body> + 'static,
+    TBody: Into<<SyncSender as Sender>::Body> + Send + 'static,
 {
     /**
     Sends a `SqlRequestBuilder` synchronously using a [`SyncClient`][SyncClient].
@@ -243,7 +243,7 @@ where
  */
 impl<TBody> SqlRequestBuilder<AsyncSender, TBody>
 where
-    TBody: Into<<AsyncSender as Sender>::Body> + 'static,
+    TBody: Into<<AsyncSender as Sender>::Body> + Send + 'static,
 {
     /**
     Sends a `SqlRequestBuilder` asynchronously using an [`AsyncClient`][AsyncClient].
@@ -298,13 +298,13 @@ where
 
 /** A future returned by calling `send`. */
 pub struct Pending {
-    inner: Box<Future<Item = SqlResponse, Error = Error>>,
+    inner: Box<Future<Item = SqlResponse, Error = Error> + Send>,
 }
 
 impl Pending {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = SqlResponse, Error = Error> + 'static,
+        F: Future<Item = SqlResponse, Error = Error> + Send + 'static,
     {
         Pending {
             inner: Box::new(fut),
@@ -323,8 +323,13 @@ impl Future for Pending {
 
 #[cfg(test)]
 mod tests {
+    use tests::*;
     use prelude::*;
-    use serde_json::Value;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::Pending>();
+    }
 
     #[test]
     fn default_request() {

--- a/src/elastic/src/client/responses/async.rs
+++ b/src/elastic/src/client/responses/async.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use futures::future::lazy;
 use futures::{
+    future::lazy,
     Future,
     Poll,
     Stream,

--- a/src/elastic/src/client/responses/async.rs
+++ b/src/elastic/src/client/responses/async.rs
@@ -155,13 +155,13 @@ impl AsyncResponseBuilder {
 
 /** A future returned by calling `into_response`. */
 pub struct IntoResponse<T> {
-    inner: Box<Future<Item = T, Error = Error>>,
+    inner: Box<Future<Item = T, Error = Error> + Send>,
 }
 
 impl<T> IntoResponse<T> {
     fn new<F>(fut: F) -> Self
     where
-        F: Future<Item = T, Error = Error> + 'static,
+        F: Future<Item = T, Error = Error> + Send + 'static,
     {
         IntoResponse {
             inner: Box::new(fut),
@@ -178,5 +178,16 @@ where
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use client;
+    use tests::*;
+
+    #[test]
+    fn is_send() {
+        assert_send::<super::IntoResponse<client::responses::PingResponse>>();
     }
 }

--- a/src/elastic/src/client/responses/mod.rs
+++ b/src/elastic/src/client/responses/mod.rs
@@ -13,8 +13,10 @@ mod sync;
 
 pub mod parse;
 
-pub use self::async::*;
-pub use self::sync::*;
+pub use self::{
+    async::*,
+    sync::*,
+};
 
 pub use elastic_responses::{
     BulkErrorsResponse,
@@ -31,14 +33,16 @@ pub use elastic_responses::{
     UpdateResponse,
 };
 
-pub use elastic_responses::bulk;
-pub use elastic_responses::search;
+pub use elastic_responses::{
+    bulk,
+    search,
+};
 
 pub mod prelude {
     /*! A glob import for convenience. */
 
-    pub use super::bulk::Action as BulkAction;
     pub use super::{
+        bulk::Action as BulkAction,
         AsyncResponseBuilder,
         BulkErrorsResponse,
         BulkResponse,

--- a/src/elastic/src/client/responses/parse.rs
+++ b/src/elastic/src/client/responses/parse.rs
@@ -89,14 +89,16 @@ See the [`IsOk`][IsOk] trait for more details.
 
 pub(crate) use elastic_responses::parse;
 
-pub use elastic_responses::error::ParseError;
-pub use elastic_responses::parsing::{
-    Buffered,
-    HttpResponseHead,
-    IsOk,
-    IsOkOnSuccess,
-    MaybeBufferedResponse,
-    MaybeOkResponse,
-    ResponseBody,
-    Unbuffered,
+pub use elastic_responses::{
+    error::ParseError,
+    parsing::{
+        Buffered,
+        HttpResponseHead,
+        IsOk,
+        IsOkOnSuccess,
+        MaybeBufferedResponse,
+        MaybeOkResponse,
+        ResponseBody,
+        Unbuffered,
+    },
 };

--- a/src/elastic/src/client/sender/async.rs
+++ b/src/elastic/src/client/sender/async.rs
@@ -1,4 +1,4 @@
-use fluent_builder::FluentBuilder;
+use fluent_builder::SharedFluentBuilder;
 use futures::{
     future::{
         lazy,
@@ -331,7 +331,7 @@ pub struct AsyncClientBuilder {
     http: Option<AsyncHttpClient>,
     serde_pool: Option<Arc<ThreadPool>>,
     nodes: NodeAddressesBuilder,
-    params: FluentBuilder<PreRequestParams>,
+    params: SharedFluentBuilder<PreRequestParams>,
     pre_send: Option<
         Arc<
             Fn(
@@ -365,7 +365,7 @@ impl AsyncClientBuilder {
         AsyncClientBuilder {
             http: None,
             serde_pool: None,
-            params: FluentBuilder::new(),
+            params: SharedFluentBuilder::new(),
             nodes: NodeAddressesBuilder::default(),
             pre_send: None,
         }
@@ -378,7 +378,7 @@ impl AsyncClientBuilder {
         AsyncClientBuilder {
             http: None,
             serde_pool: None,
-            params: FluentBuilder::new().value(params),
+            params: SharedFluentBuilder::new().value(params),
             nodes: NodeAddressesBuilder::default(),
             pre_send: None,
         }
@@ -467,7 +467,7 @@ impl AsyncClientBuilder {
         mut self,
         builder: impl Fn(PreRequestParams) -> PreRequestParams + Send + 'static,
     ) -> Self {
-        self.params = self.params.fluent(builder).boxed();
+        self.params = self.params.fluent(builder).shared();
 
         self
     }

--- a/src/elastic/src/client/sender/async.rs
+++ b/src/elastic/src/client/sender/async.rs
@@ -1,10 +1,10 @@
 use fluent_builder::FluentBuilder;
-use futures::future::{
-    lazy,
-    Either,
-    FutureResult,
-};
 use futures::{
+    future::{
+        lazy,
+        Either,
+        FutureResult,
+    },
     Future,
     IntoFuture,
     Poll,
@@ -13,34 +13,38 @@ use reqwest::async::{
     Client as AsyncHttpClient,
     RequestBuilder as AsyncHttpRequestBuilder,
 };
-use std::error::Error as StdError;
-use std::sync::Arc;
+use std::{
+    error::Error as StdError,
+    sync::Arc,
+};
 use tokio_threadpool::{
     SpawnHandle,
     ThreadPool,
 };
 
-use client::requests::Endpoint;
-use client::responses::{
-    async_response,
-    AsyncResponseBuilder,
+use client::{
+    requests::Endpoint,
+    responses::{
+        async_response,
+        AsyncResponseBuilder,
+    },
+    sender::{
+        build_reqwest_method,
+        build_url,
+        sniffed_nodes::SniffedNodesBuilder,
+        NextParams,
+        NodeAddress,
+        NodeAddresses,
+        NodeAddressesBuilder,
+        NodeAddressesInner,
+        PreRequestParams,
+        RequestParams,
+        SendableRequest,
+        SendableRequestParams,
+        Sender,
+    },
+    Client,
 };
-use client::sender::sniffed_nodes::SniffedNodesBuilder;
-use client::sender::{
-    build_reqwest_method,
-    build_url,
-    NextParams,
-    NodeAddress,
-    NodeAddresses,
-    NodeAddressesBuilder,
-    NodeAddressesInner,
-    PreRequestParams,
-    RequestParams,
-    SendableRequest,
-    SendableRequestParams,
-    Sender,
-};
-use client::Client;
 use error::{
     self,
     Error,
@@ -95,7 +99,8 @@ pub struct AsyncSender {
         Arc<
             Fn(
                     &mut AsyncHttpRequest,
-                ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>> + Send>
+                )
+                    -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>> + Send>
                 + Send
                 + Sync,
         >,
@@ -331,7 +336,8 @@ pub struct AsyncClientBuilder {
         Arc<
             Fn(
                     &mut AsyncHttpRequest,
-                ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>> + Send>
+                )
+                    -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>> + Send>
                 + Send
                 + Sync,
         >,
@@ -527,7 +533,8 @@ impl AsyncClientBuilder {
         mut self,
         pre_send: impl Fn(
                 &mut AsyncHttpRequest,
-            ) -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>> + Send>
+            )
+                -> Box<Future<Item = (), Error = Box<StdError + Send + Sync>> + Send>
             + Send
             + Sync
             + 'static,

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -103,8 +103,8 @@ pub trait Sender: private::Sealed + Clone {
     ) -> Self::Response
     where
         TEndpoint: Into<Endpoint<'static, TBody>>,
-        TBody: Into<Self::Body> + 'static,
-        TParams: Into<Self::Params> + 'static;
+        TBody: Into<Self::Body> + Send + 'static,
+        TParams: Into<Self::Params> + Send + 'static;
 }
 
 /**
@@ -194,7 +194,7 @@ impl NodeAddressesBuilder {
 
     fn sniff_nodes_fluent<F>(self, address: NodeAddress, fleunt_method: F) -> Self
     where
-        F: FnOnce(SniffedNodesBuilder) -> SniffedNodesBuilder + 'static,
+        F: FnOnce(SniffedNodesBuilder) -> SniffedNodesBuilder + Send + 'static,
     {
         match self {
             NodeAddressesBuilder::Sniffed(fluent_builder) => NodeAddressesBuilder::Sniffed(

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -14,8 +14,8 @@ Some notable types include:
 */
 
 use fluent_builder::{
-    FluentBuilder,
-    StatefulFluentBuilder,
+    SharedFluentBuilder,
+    SharedStatefulFluentBuilder,
 };
 
 pub mod sniffed_nodes;
@@ -76,7 +76,7 @@ pub(crate) enum SendableRequestParams<TParams> {
     Value(RequestParams),
     Builder {
         params: TParams,
-        builder: FluentBuilder<RequestParams>,
+        builder: SharedFluentBuilder<RequestParams>,
     },
 }
 
@@ -185,7 +185,7 @@ enum NodeAddressesInner<TSender> {
 
 enum NodeAddressesBuilder {
     Static(Vec<NodeAddress>),
-    Sniffed(StatefulFluentBuilder<SniffedNodesBuilder, NodeAddress>),
+    Sniffed(SharedStatefulFluentBuilder<SniffedNodesBuilder, NodeAddress>),
 }
 
 impl NodeAddressesBuilder {
@@ -194,7 +194,7 @@ impl NodeAddressesBuilder {
             NodeAddressesBuilder::Sniffed(fluent_builder) => {
                 NodeAddressesBuilder::Sniffed(fluent_builder.value(builder))
             }
-            _ => NodeAddressesBuilder::Sniffed(StatefulFluentBuilder::from_value(builder.into())),
+            _ => NodeAddressesBuilder::Sniffed(SharedStatefulFluentBuilder::from_value(builder.into())),
         }
     }
 
@@ -204,10 +204,10 @@ impl NodeAddressesBuilder {
     {
         match self {
             NodeAddressesBuilder::Sniffed(fluent_builder) => NodeAddressesBuilder::Sniffed(
-                fluent_builder.fluent(address.into(), fleunt_method).boxed(),
+                fluent_builder.fluent(address.into(), fleunt_method).shared(),
             ),
             _ => NodeAddressesBuilder::Sniffed(
-                StatefulFluentBuilder::from_fluent(address.into(), fleunt_method).boxed(),
+                SharedStatefulFluentBuilder::from_fluent(address.into(), fleunt_method).shared(),
             ),
         }
     }

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -185,7 +185,7 @@ enum NodeAddressesInner<TSender> {
 
 enum NodeAddressesBuilder {
     Static(Vec<NodeAddress>),
-    Sniffed(SharedStatefulFluentBuilder<SniffedNodesBuilder, NodeAddress>),
+    Sniffed(SharedStatefulFluentBuilder<NodeAddress, SniffedNodesBuilder>),
 }
 
 impl NodeAddressesBuilder {
@@ -207,7 +207,7 @@ impl NodeAddressesBuilder {
                 fluent_builder.fluent(address.into(), fleunt_method).shared(),
             ),
             _ => NodeAddressesBuilder::Sniffed(
-                SharedStatefulFluentBuilder::from_fluent(address.into(), fleunt_method).shared(),
+                SharedStatefulFluentBuilder::from_fluent(address.into(), fleunt_method),
             ),
         }
     }

--- a/src/elastic/src/client/sender/mod.rs
+++ b/src/elastic/src/client/sender/mod.rs
@@ -24,19 +24,25 @@ pub mod static_nodes;
 mod async;
 mod params;
 mod sync;
-pub use self::async::*;
-pub use self::params::*;
-pub use self::sync::*;
+pub use self::{
+    async::*,
+    params::*,
+    sync::*,
+};
 
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{
+    marker::PhantomData,
+    sync::Arc,
+};
 use uuid::Uuid;
 
-use self::sniffed_nodes::{
-    SniffedNodes,
-    SniffedNodesBuilder,
+use self::{
+    sniffed_nodes::{
+        SniffedNodes,
+        SniffedNodesBuilder,
+    },
+    static_nodes::StaticNodes,
 };
-use self::static_nodes::StaticNodes;
 use client::requests::Endpoint;
 use private;
 

--- a/src/elastic/src/client/sender/params.rs
+++ b/src/elastic/src/client/sender/params.rs
@@ -1,12 +1,16 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
 
-use reqwest;
-use reqwest::header::{
-    HeaderMap,
-    HeaderName,
-    HeaderValue,
-    CONTENT_TYPE,
+use reqwest::{
+    self,
+    header::{
+        HeaderMap,
+        HeaderName,
+        HeaderValue,
+        CONTENT_TYPE,
+    },
 };
 use url::form_urlencoded::Serializer;
 

--- a/src/elastic/src/client/sender/sniffed_nodes/mod.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/mod.rs
@@ -104,12 +104,12 @@ impl<TSender> SniffedNodes<TSender> {
     fn async_next<TRefresh, TRefreshFuture>(
         &self,
         refresh: TRefresh,
-    ) -> Box<Future<Item = RequestParams, Error = Error>>
+    ) -> Box<Future<Item = RequestParams, Error = Error> + Send>
     where
         TRefresh: Fn(
             SendableRequest<NodesInfoRequest<'static>, RequestParams, DefaultBody>,
         ) -> TRefreshFuture,
-        TRefreshFuture: Future<Item = NodesInfoResponse, Error = Error> + 'static,
+        TRefreshFuture: Future<Item = NodesInfoResponse, Error = Error> + Send + 'static,
     {
         if let Some(address) = self.next_or_start_refresh() {
             return Box::new(address.into_future());
@@ -343,7 +343,7 @@ impl SniffedNodesInner {
 impl<TSender> private::Sealed for SniffedNodes<TSender> {}
 
 impl NextParams for SniffedNodes<AsyncSender> {
-    type Params = Box<Future<Item = RequestParams, Error = Error>>;
+    type Params = Box<Future<Item = RequestParams, Error = Error> + Send>;
 
     fn next(&self) -> Self::Params {
         self.async_next(|req| {

--- a/src/elastic/src/client/sender/sniffed_nodes/mod.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/mod.rs
@@ -30,31 +30,35 @@ use futures::{
     Future,
     IntoFuture,
 };
-use std::sync::{
-    Arc,
-    RwLock,
-};
-use std::time::{
-    Duration,
-    Instant,
+use std::{
+    sync::{
+        Arc,
+        RwLock,
+    },
+    time::{
+        Duration,
+        Instant,
+    },
 };
 use url::Url;
 
-use client::requests::{
-    DefaultBody,
-    NodesInfoRequest,
-};
-use client::sender::static_nodes::StaticNodes;
-use client::sender::{
-    AsyncSender,
-    NextParams,
-    NodeAddress,
-    PreRequestParams,
-    RequestParams,
-    SendableRequest,
-    SendableRequestParams,
-    Sender,
-    SyncSender,
+use client::{
+    requests::{
+        DefaultBody,
+        NodesInfoRequest,
+    },
+    sender::{
+        static_nodes::StaticNodes,
+        AsyncSender,
+        NextParams,
+        NodeAddress,
+        PreRequestParams,
+        RequestParams,
+        SendableRequest,
+        SendableRequestParams,
+        Sender,
+        SyncSender,
+    },
 };
 use error::{
     self,

--- a/src/elastic/src/client/sender/sniffed_nodes/nodes_info.rs
+++ b/src/elastic/src/client/sender/sniffed_nodes/nodes_info.rs
@@ -9,8 +9,10 @@ use serde::de::{
 };
 use std::fmt;
 
-use std::iter::IntoIterator;
-use std::vec::IntoIter;
+use std::{
+    iter::IntoIterator,
+    vec::IntoIter,
+};
 
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct NodesInfoResponse {

--- a/src/elastic/src/client/sender/static_nodes.rs
+++ b/src/elastic/src/client/sender/static_nodes.rs
@@ -11,11 +11,13 @@ use error::{
     Error,
 };
 use private;
-use std::sync::atomic::{
-    AtomicUsize,
-    Ordering,
+use std::sync::{
+    atomic::{
+        AtomicUsize,
+        Ordering,
+    },
+    Arc,
 };
-use std::sync::Arc;
 
 /** Select a base address for a given request using some strategy. */
 #[derive(Clone)]

--- a/src/elastic/src/client/sender/static_nodes.rs
+++ b/src/elastic/src/client/sender/static_nodes.rs
@@ -85,10 +85,10 @@ pub trait Strategy: Send + Sync {
     fn try_next(&self, nodes: &[NodeAddress]) -> Result<NodeAddress, StrategyError>;
 }
 
-/**
-An error attempting to get an address using a strategy.
-*/
 quick_error! {
+    /**
+    An error attempting to get an address using a strategy.
+    */
     #[derive(Debug)]
     pub enum StrategyError {
         Empty {

--- a/src/elastic/src/client/sender/sync.rs
+++ b/src/elastic/src/client/sender/sync.rs
@@ -4,30 +4,34 @@ use reqwest::{
     ClientBuilder as SyncHttpClientBuilder,
     RequestBuilder as SyncHttpRequestBuilder,
 };
-use std::error::Error as StdError;
-use std::sync::Arc;
+use std::{
+    error::Error as StdError,
+    sync::Arc,
+};
 
-use client::requests::Endpoint;
-use client::responses::{
-    sync_response,
-    SyncResponseBuilder,
+use client::{
+    requests::Endpoint,
+    responses::{
+        sync_response,
+        SyncResponseBuilder,
+    },
+    sender::{
+        build_reqwest_method,
+        build_url,
+        sniffed_nodes::SniffedNodesBuilder,
+        NextParams,
+        NodeAddress,
+        NodeAddresses,
+        NodeAddressesBuilder,
+        NodeAddressesInner,
+        PreRequestParams,
+        RequestParams,
+        SendableRequest,
+        SendableRequestParams,
+        Sender,
+    },
+    Client,
 };
-use client::sender::sniffed_nodes::SniffedNodesBuilder;
-use client::sender::{
-    build_reqwest_method,
-    build_url,
-    NextParams,
-    NodeAddress,
-    NodeAddresses,
-    NodeAddressesBuilder,
-    NodeAddressesInner,
-    PreRequestParams,
-    RequestParams,
-    SendableRequest,
-    SendableRequestParams,
-    Sender,
-};
-use client::Client;
 use error::{
     self,
     Error,

--- a/src/elastic/src/client/sender/sync.rs
+++ b/src/elastic/src/client/sender/sync.rs
@@ -90,8 +90,8 @@ impl Sender for SyncSender {
     ) -> Self::Response
     where
         TEndpoint: Into<Endpoint<'static, TBody>>,
-        TBody: Into<Self::Body> + 'static,
-        TParams: Into<Self::Params> + 'static,
+        TBody: Into<Self::Body> + Send + 'static,
+        TParams: Into<Self::Params> + Send + 'static,
     {
         let correlation_id = request.correlation_id;
         let params = request.params;
@@ -339,7 +339,7 @@ impl SyncClientBuilder {
     pub fn sniff_nodes_fluent(
         mut self,
         address: impl Into<NodeAddress>,
-        builder: impl Fn(SniffedNodesBuilder) -> SniffedNodesBuilder + 'static,
+        builder: impl Fn(SniffedNodesBuilder) -> SniffedNodesBuilder + Send + 'static,
     ) -> Self {
         self.nodes = self.nodes.sniff_nodes_fluent(address.into(), builder);
 
@@ -362,7 +362,7 @@ impl SyncClientBuilder {
     */
     pub fn params_fluent(
         mut self,
-        builder: impl Fn(PreRequestParams) -> PreRequestParams + 'static,
+        builder: impl Fn(PreRequestParams) -> PreRequestParams + Send + 'static,
     ) -> Self {
         self.params = self.params.fluent(builder).boxed();
 

--- a/src/elastic/src/client/sender/sync.rs
+++ b/src/elastic/src/client/sender/sync.rs
@@ -1,4 +1,4 @@
-use fluent_builder::FluentBuilder;
+use fluent_builder::SharedFluentBuilder;
 use reqwest::{
     Client as SyncHttpClient,
     ClientBuilder as SyncHttpClientBuilder,
@@ -237,7 +237,7 @@ fn build_reqwest(client: &SyncHttpClient, req: SyncHttpRequest) -> SyncHttpReque
 pub struct SyncClientBuilder {
     http: Option<SyncHttpClient>,
     nodes: NodeAddressesBuilder,
-    params: FluentBuilder<PreRequestParams>,
+    params: SharedFluentBuilder<PreRequestParams>,
     pre_send: Option<
         Arc<
             Fn(&mut SyncHttpRequest) -> Result<(), Box<StdError + Send + Sync>>
@@ -268,7 +268,7 @@ impl SyncClientBuilder {
         SyncClientBuilder {
             http: None,
             nodes: NodeAddressesBuilder::default(),
-            params: FluentBuilder::new(),
+            params: SharedFluentBuilder::new(),
             pre_send: None,
         }
     }
@@ -280,7 +280,7 @@ impl SyncClientBuilder {
         SyncClientBuilder {
             http: None,
             nodes: NodeAddressesBuilder::default(),
-            params: FluentBuilder::new().value(params),
+            params: SharedFluentBuilder::new().value(params),
             pre_send: None,
         }
     }
@@ -368,7 +368,7 @@ impl SyncClientBuilder {
         mut self,
         builder: impl Fn(PreRequestParams) -> PreRequestParams + Send + 'static,
     ) -> Self {
-        self.params = self.params.fluent(builder).boxed();
+        self.params = self.params.fluent(builder).shared();
 
         self
     }

--- a/src/elastic/src/error.rs
+++ b/src/elastic/src/error.rs
@@ -37,9 +37,11 @@ match response {
 ```
 */
 
-use std::error::Error as StdError;
-use std::fmt;
-use std::io;
+use std::{
+    error::Error as StdError,
+    fmt,
+    io,
+};
 
 use elastic_responses::error::ResponseError;
 use reqwest::Error as ReqwestError;

--- a/src/elastic/src/error.rs
+++ b/src/elastic/src/error.rs
@@ -52,16 +52,16 @@ use http::StatusCode;
 /** An alias for a result. */
 pub type Result<T> = ::std::result::Result<T, Error>;
 
-/**
-An error encountered while interacting with Elasticsearch.
-
-API errors can be easily matched and destructured whereas client errors
-can be formatted, but not destructured.
-
-If the `RUST_BACKTRACE` environment variable is `1` then client errors will
-also contain a backtrace.
-*/
 quick_error! {
+    /**
+    An error encountered while interacting with Elasticsearch.
+
+    API errors can be easily matched and destructured whereas client errors
+    can be formatted, but not destructured.
+
+    If the `RUST_BACKTRACE` environment variable is `1` then client errors will
+    also contain a backtrace.
+    */
     #[derive(Debug)]
     pub enum Error {
         /** An API error from Elasticsearch. */

--- a/src/elastic/src/http/async.rs
+++ b/src/elastic/src/http/async.rs
@@ -1,10 +1,12 @@
 use bytes::Bytes;
 use serde_json::Value;
-use std::borrow::Cow;
-use std::io::{
-    self,
-    Cursor,
-    Read,
+use std::{
+    borrow::Cow,
+    io::{
+        self,
+        Cursor,
+        Read,
+    },
 };
 
 use futures::{

--- a/src/elastic/src/http/mod.rs
+++ b/src/elastic/src/http/mod.rs
@@ -8,11 +8,15 @@ They may eventually be wrapped and made implementation details.
 mod async;
 mod sync;
 
-pub use self::async::*;
-pub use self::sync::*;
+pub use self::{
+    async::*,
+    sync::*,
+};
 
-pub use reqwest::header;
-pub use reqwest::Url;
+pub use reqwest::{
+    header,
+    Url,
+};
 
 pub use elastic_requests::Method;
 pub use elastic_responses::StatusCode;

--- a/src/elastic/src/http/sync.rs
+++ b/src/elastic/src/http/sync.rs
@@ -1,11 +1,13 @@
 use bytes::Bytes;
 use serde_json::Value;
-use std::borrow::Cow;
-use std::fs::File;
-use std::io::{
-    self,
-    Cursor,
-    Read,
+use std::{
+    borrow::Cow,
+    fs::File,
+    io::{
+        self,
+        Cursor,
+        Read,
+    },
 };
 
 use reqwest::{

--- a/src/queries/src/aggregations/date_histogram.rs
+++ b/src/queries/src/aggregations/date_histogram.rs
@@ -1,5 +1,7 @@
-use super::BucketAggregation;
-use super::EsAggregation;
+use super::{
+    BucketAggregation,
+    EsAggregation,
+};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/queries/src/aggregations/mod.rs
+++ b/src/queries/src/aggregations/mod.rs
@@ -2,16 +2,22 @@ pub(crate) mod date_histogram;
 pub(crate) mod stats;
 pub(crate) mod terms;
 
-use self::date_histogram::DateHistogramAggregation;
-use self::stats::{
-    AvgAggregation,
-    MaxAggregation,
-    SumAggregation,
+use self::{
+    date_histogram::DateHistogramAggregation,
+    stats::{
+        AvgAggregation,
+        MaxAggregation,
+        SumAggregation,
+    },
+    terms::TermAggregation,
 };
-use self::terms::TermAggregation;
-use std::collections::hash_map::Iter;
-use std::collections::HashMap;
-use std::option::Option;
+use std::{
+    collections::{
+        hash_map::Iter,
+        HashMap,
+    },
+    option::Option,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -288,8 +294,10 @@ impl<'i> Iterator for AggregationIterator<'i> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::Query;
-    use super::*;
+    use super::{
+        super::Query,
+        *,
+    };
     use serde_json;
 
     #[test]

--- a/src/queries/src/aggregations/terms.rs
+++ b/src/queries/src/aggregations/terms.rs
@@ -1,6 +1,8 @@
-use super::super::filters::common::*;
-use super::BucketAggregation;
-use super::EsAggregation;
+use super::{
+    super::filters::common::*,
+    BucketAggregation,
+    EsAggregation,
+};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/queries/src/filters/common.rs
+++ b/src/queries/src/filters/common.rs
@@ -1,10 +1,12 @@
 use super::super::Values;
-use serde;
-use serde::de::Visitor;
-use serde::ser::{
-    Serialize,
-    SerializeMap,
-    Serializer,
+use serde::{
+    self,
+    de::Visitor,
+    ser::{
+        Serialize,
+        SerializeMap,
+        Serializer,
+    },
 };
 use std::fmt;
 

--- a/src/queries/src/filters/mod.rs
+++ b/src/queries/src/filters/mod.rs
@@ -5,11 +5,13 @@ pub(crate) mod range;
 pub(crate) mod term;
 pub(crate) mod wildcard;
 
-pub(crate) use self::exists::ExistsFilter;
-pub(crate) use self::matchfilter::MatchFilter;
-pub(crate) use self::range::RangeFilter;
-pub(crate) use self::term::TermFilter;
-pub(crate) use self::wildcard::WildcardFilter;
+pub(crate) use self::{
+    exists::ExistsFilter,
+    matchfilter::MatchFilter,
+    range::RangeFilter,
+    term::TermFilter,
+    wildcard::WildcardFilter,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
 #[serde(untagged)]

--- a/src/queries/src/filters/range.rs
+++ b/src/queries/src/filters/range.rs
@@ -1,11 +1,15 @@
-use super::super::Values;
-use super::common::EsDateFormat;
-use serde;
-use serde::de::Visitor;
-use serde::ser::{
-    Serialize,
-    SerializeMap,
-    Serializer,
+use super::{
+    super::Values,
+    common::EsDateFormat,
+};
+use serde::{
+    self,
+    de::Visitor,
+    ser::{
+        Serialize,
+        SerializeMap,
+        Serializer,
+    },
 };
 use std::fmt;
 

--- a/src/queries/src/filters/term.rs
+++ b/src/queries/src/filters/term.rs
@@ -1,5 +1,7 @@
-use super::super::filters::common::*;
-use super::super::Values;
+use super::super::{
+    filters::common::*,
+    Values,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
 pub struct TermFilter {

--- a/src/queries/src/lib.rs
+++ b/src/queries/src/lib.rs
@@ -15,9 +15,11 @@ mod aggregations;
 mod filters;
 pub mod prelude;
 
-use aggregations::Aggregation;
-use aggregations::BucketAggregation;
-use aggregations::EsAggregation;
+use aggregations::{
+    Aggregation,
+    BucketAggregation,
+    EsAggregation,
+};
 use filters::Filters;
 use std::collections::HashMap;
 
@@ -333,8 +335,10 @@ impl QueryBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::filters::*;
-    use super::*;
+    use super::{
+        filters::*,
+        *,
+    };
 
     #[test]
     fn root_to_target() {

--- a/src/queries/src/prelude.rs
+++ b/src/queries/src/prelude.rs
@@ -1,7 +1,9 @@
-pub use filters::common::EsDateFormat;
-pub use filters::range::{
-    RangeFilter,
-    RangeParamsBuilder,
+pub use filters::{
+    common::EsDateFormat,
+    range::{
+        RangeFilter,
+        RangeParamsBuilder,
+    },
 };
 pub use BoolQuerySections;
 pub use Query;

--- a/src/requests/src/genned.rs
+++ b/src/requests/src/genned.rs
@@ -1,8 +1,10 @@
 /*This code is automatically generated
 */
 pub mod endpoints {
-    use super::http::*;
-    use super::params::*;
+    use super::{
+        http::*,
+        params::*,
+    };
 
     #[derive(Debug, PartialEq, Clone)]
     enum IndicesRefreshUrlParams<'a> {
@@ -6628,8 +6630,10 @@ pub mod endpoints {
 }
 
 pub mod http {
-    use std::borrow::Cow;
-    use std::ops::Deref;
+    use std::{
+        borrow::Cow,
+        ops::Deref,
+    };
     extern crate http;
     pub use self::http::Method;
 

--- a/src/requests/src/lib.rs
+++ b/src/requests/src/lib.rs
@@ -112,8 +112,10 @@ pub mod endpoints {
     pub use genned::endpoints::*;
 }
 
-pub use self::endpoints::*;
-pub use self::params::*;
+pub use self::{
+    endpoints::*,
+    params::*,
+};
 pub use genned::http::*;
 
 #[cfg(test)]

--- a/src/requests_codegen/src/gen/request_ctors.rs
+++ b/src/requests_codegen/src/gen/request_ctors.rs
@@ -1,5 +1,7 @@
-use super::helpers::*;
-use super::types;
+use super::{
+    helpers::*,
+    types,
+};
 use parse::Endpoint;
 use syn;
 

--- a/src/requests_codegen/src/gen/request_into_endpoint.rs
+++ b/src/requests_codegen/src/gen/request_into_endpoint.rs
@@ -1,5 +1,7 @@
-use super::helpers::*;
-use super::types;
+use super::{
+    helpers::*,
+    types,
+};
 use parse::{
     Endpoint,
     Method,

--- a/src/requests_codegen/src/gen/request_params.rs
+++ b/src/requests_codegen/src/gen/request_params.rs
@@ -1,5 +1,7 @@
-use super::helpers::*;
-use super::types;
+use super::{
+    helpers::*,
+    types,
+};
 use parse;
 use syn;
 

--- a/src/requests_codegen/src/gen/url_builder.rs
+++ b/src/requests_codegen/src/gen/url_builder.rs
@@ -1,5 +1,7 @@
-use super::helpers::*;
-use super::types;
+use super::{
+    helpers::*,
+    types,
+};
 use parse::{
     Endpoint,
     PathPart,

--- a/src/requests_codegen/src/main.rs
+++ b/src/requests_codegen/src/main.rs
@@ -18,15 +18,17 @@ extern crate inflector;
 pub mod gen;
 pub mod parse;
 
-use std::collections::BTreeMap;
-use std::fs::{
-    read_dir,
-    File,
-};
-use std::io::{
-    stdout,
-    Read,
-    Write,
+use std::{
+    collections::BTreeMap,
+    fs::{
+        read_dir,
+        File,
+    },
+    io::{
+        stdout,
+        Read,
+        Write,
+    },
 };
 
 use parse::*;

--- a/src/requests_codegen/src/parse/mod.rs
+++ b/src/requests_codegen/src/parse/mod.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
-use std::collections::BTreeMap;
-use std::fmt;
+use std::{
+    collections::BTreeMap,
+    fmt,
+};
 
 mod parse;
 
@@ -431,8 +433,10 @@ mod tests {
 
     mod ser {
         use parse::*;
-        use serde_json;
-        use serde_json::value::to_value;
+        use serde_json::{
+            self,
+            value::to_value,
+        };
         use std::collections::BTreeMap;
 
         fn http_eq(expected: Method, ser: &'static str) {

--- a/src/responses/src/bulk.rs
+++ b/src/responses/src/bulk.rs
@@ -19,12 +19,14 @@ use serde_json::Value;
 
 use parsing::IsOkOnSuccess;
 
-use std::cmp;
-use std::error::Error;
-use std::fmt;
-use std::marker::PhantomData;
-use std::slice::Iter;
-use std::vec::IntoIter;
+use std::{
+    cmp,
+    error::Error,
+    fmt,
+    marker::PhantomData,
+    slice::Iter,
+    vec::IntoIter,
+};
 
 type BulkError = Value;
 
@@ -517,7 +519,9 @@ impl<TIndex, TType, TId> ErrorItem<TIndex, TType, TId> {
     }
 
     /** Raw error JSON. */
-    pub fn err(&self) -> &BulkError { &self.err }
+    pub fn err(&self) -> &BulkError {
+        &self.err
+    }
 }
 
 impl<TIndex, TType, TId> fmt::Display for ErrorItem<TIndex, TType, TId>

--- a/src/responses/src/error.rs
+++ b/src/responses/src/error.rs
@@ -11,17 +11,21 @@ use serde_json::{
     Map,
     Value,
 };
-use std::error::Error as StdError;
-use std::fmt;
-use std::io::Error as IoError;
+use std::{
+    error::Error as StdError,
+    fmt,
+    io::Error as IoError,
+};
 
 mod inner {
     use serde_json::{
         Map,
         Value,
     };
-    use std::error::Error as StdError;
-    use std::fmt;
+    use std::{
+        error::Error as StdError,
+        fmt,
+    };
 
     use super::ApiError;
 

--- a/src/responses/src/lib.rs
+++ b/src/responses/src/lib.rs
@@ -153,19 +153,21 @@ mod update;
 
 mod indices_exists;
 
-pub use self::bulk::{
-    BulkErrorsResponse,
-    BulkResponse,
+pub use self::{
+    bulk::{
+        BulkErrorsResponse,
+        BulkResponse,
+    },
+    command::*,
+    common::*,
+    delete::*,
+    get::*,
+    index::*,
+    ping::*,
+    search::SearchResponse,
+    sql::*,
+    update::*,
 };
-pub use self::command::*;
-pub use self::common::*;
-pub use self::delete::*;
-pub use self::get::*;
-pub use self::index::*;
-pub use self::ping::*;
-pub use self::search::SearchResponse;
-pub use self::sql::*;
-pub use self::update::*;
 
 pub use self::indices_exists::*;
 

--- a/src/responses/src/parsing.rs
+++ b/src/responses/src/parsing.rs
@@ -8,11 +8,13 @@ use serde_json::{
     self,
     Value,
 };
-use std::io::{
-    Cursor,
-    Read,
+use std::{
+    io::{
+        Cursor,
+        Read,
+    },
+    marker::PhantomData,
 };
-use std::marker::PhantomData;
 
 use error::*;
 

--- a/src/responses/src/search.rs
+++ b/src/responses/src/search.rs
@@ -11,10 +11,12 @@ use serde_json::{
 use common::Shards;
 use parsing::IsOkOnSuccess;
 
-use std::borrow::Cow;
-use std::collections::BTreeMap;
-use std::slice::Iter;
-use std::vec::IntoIter;
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    slice::Iter,
+    vec::IntoIter,
+};
 
 /**
 Response for a [search request][search-req].

--- a/src/responses/tests/bulk/mod.rs
+++ b/src/responses/tests/bulk/mod.rs
@@ -1,8 +1,10 @@
 extern crate elastic_responses;
 extern crate serde_json;
 
-use elastic_responses::error::*;
-use elastic_responses::*;
+use elastic_responses::{
+    error::*,
+    *,
+};
 use load_file;
 
 #[test]

--- a/src/responses/tests/get/mod.rs
+++ b/src/responses/tests/get/mod.rs
@@ -1,8 +1,10 @@
 extern crate elastic_responses;
 extern crate serde_json;
 
-use elastic_responses::error::*;
-use elastic_responses::*;
+use elastic_responses::{
+    error::*,
+    *,
+};
 use load_file;
 use serde_json::Value;
 

--- a/src/responses/tests/index/mod.rs
+++ b/src/responses/tests/index/mod.rs
@@ -1,8 +1,10 @@
 extern crate elastic_responses;
 extern crate serde_json;
 
-use elastic_responses::error::*;
-use elastic_responses::*;
+use elastic_responses::{
+    error::*,
+    *,
+};
 use load_file;
 
 #[test]

--- a/src/responses/tests/search/mod.rs
+++ b/src/responses/tests/search/mod.rs
@@ -2,8 +2,10 @@ extern crate elastic_responses;
 extern crate serde;
 extern crate serde_json;
 
-use elastic_responses::error::*;
-use elastic_responses::*;
+use elastic_responses::{
+    error::*,
+    *,
+};
 use load_file;
 use serde_json::Value;
 

--- a/src/types/src/boolean/impls.rs
+++ b/src/types/src/boolean/impls.rs
@@ -3,18 +3,20 @@ use super::mapping::{
     BooleanMapping,
     DefaultBooleanMapping,
 };
-use serde::de::{
-    Error,
-    Visitor,
-};
 use serde::{
+    de::{
+        Error,
+        Visitor,
+    },
     Deserialize,
     Deserializer,
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+};
 
 impl BooleanFieldType<DefaultBooleanMapping> for bool {}
 

--- a/src/types/src/boolean/mapping.rs
+++ b/src/types/src/boolean/mapping.rs
@@ -116,8 +116,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/boolean/mod.rs
+++ b/src/types/src/boolean/mod.rs
@@ -63,6 +63,8 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::*;
-    pub use super::mapping::*;
+    pub use super::{
+        impls::*,
+        mapping::*,
+    };
 }

--- a/src/types/src/date/format.rs
+++ b/src/types/src/date/format.rs
@@ -1,25 +1,27 @@
 use super::ChronoDateTime;
-use chrono::format::{
-    DelayedFormat,
-    Item,
-};
 use chrono::{
     self,
+    format::{
+        DelayedFormat,
+        Item,
+    },
     NaiveDate,
     NaiveDateTime,
     NaiveTime,
     Utc,
 };
-use std::borrow::Borrow;
-use std::error::Error;
-use std::fmt::{
-    Display,
-    Formatter,
-    Result as FmtResult,
+use std::{
+    borrow::Borrow,
+    error::Error,
+    fmt::{
+        Display,
+        Formatter,
+        Result as FmtResult,
+    },
+    marker::PhantomData,
+    ops::Deref,
+    vec::IntoIter,
 };
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::vec::IntoIter;
 
 /**
 A date value produced and consumed by date formats.

--- a/src/types/src/date/impls.rs
+++ b/src/types/src/date/impls.rs
@@ -1,39 +1,43 @@
-use super::format::{
-    DateFormat,
-    DateValue,
-    FormattableDateValue,
-    FormattedDate,
-    ParseError,
-};
-use super::formats::ChronoFormat;
-use super::mapping::{
-    DateFieldType,
-    DateMapping,
-    DefaultDateMapping,
+use super::{
+    format::{
+        DateFormat,
+        DateValue,
+        FormattableDateValue,
+        FormattedDate,
+        ParseError,
+    },
+    formats::ChronoFormat,
+    mapping::{
+        DateFieldType,
+        DateMapping,
+        DefaultDateMapping,
+    },
 };
 use chrono::{
     DateTime,
     Utc,
 };
 use private::field::StdField;
-use serde::de::{
-    Error,
-    Visitor,
-};
 use serde::{
+    de::{
+        Error,
+        Visitor,
+    },
     Deserialize,
     Deserializer,
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::fmt::{
-    Display,
-    Formatter,
-    Result as FmtResult,
+use std::{
+    borrow::Borrow,
+    fmt::{
+        Display,
+        Formatter,
+        Result as FmtResult,
+    },
+    marker::PhantomData,
+    ops::Deref,
 };
-use std::marker::PhantomData;
-use std::ops::Deref;
 
 pub use chrono::{
     Datelike,
@@ -680,8 +684,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use chrono;
-    use chrono::offset::TimeZone;
+    use chrono::{
+        self,
+        offset::TimeZone,
+    };
     use serde_json;
 
     use prelude::*;

--- a/src/types/src/date/mapping.rs
+++ b/src/types/src/date/mapping.rs
@@ -198,8 +198,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/date/mod.rs
+++ b/src/types/src/date/mod.rs
@@ -124,9 +124,11 @@ pub mod mapping;
 mod format;
 mod formats;
 mod impls;
-pub use self::format::*;
-pub use self::formats::*;
-pub use self::impls::*;
+pub use self::{
+    format::*,
+    formats::*,
+    impls::*,
+};
 
 pub mod prelude {
     /*!
@@ -135,14 +137,16 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::format::{
-        DateFormat,
-        DateValue,
-        FormattableDateValue,
-        FormattedDate,
+    pub use super::{
+        format::{
+            DateFormat,
+            DateValue,
+            FormattableDateValue,
+            FormattedDate,
+        },
+        formats::*,
+        impls::*,
+        mapping::*,
+        DefaultDateFormat,
     };
-    pub use super::formats::*;
-    pub use super::impls::*;
-    pub use super::mapping::*;
-    pub use super::DefaultDateFormat;
 }

--- a/src/types/src/derive.rs
+++ b/src/types/src/derive.rs
@@ -5,11 +5,11 @@ This module is 'private' and should only be consumed by `elastic_types_derive`.
 Its contents aren't subject to SemVer.
 */
 
-use chrono::format::{
-    self,
-    Parsed,
-};
 use chrono::{
+    format::{
+        self,
+        Parsed,
+    },
     DateTime,
     Utc,
 };
@@ -28,12 +28,12 @@ pub use date::{
     FormattedDate,
     ParseError,
 };
-pub use document::mapping::{
-    ObjectFieldType,
-    ObjectMapping,
-    PropertiesMapping,
-};
 pub use document::{
+    mapping::{
+        ObjectFieldType,
+        ObjectMapping,
+        PropertiesMapping,
+    },
     DocumentType,
     StaticIndex,
     StaticType,

--- a/src/types/src/document/impls.rs
+++ b/src/types/src/document/impls.rs
@@ -5,8 +5,10 @@ use super::mapping::{
 };
 use serde::ser::SerializeStruct;
 use serde_json::Value;
-use std::borrow::Cow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Cow,
+    marker::PhantomData,
+};
 
 /**
 The default name for document types in a single document index.
@@ -426,8 +428,10 @@ mod tests {
         self,
         Value,
     };
-    use std::borrow::Cow;
-    use std::collections::HashSet;
+    use std::{
+        borrow::Cow,
+        collections::HashSet,
+    };
 
     // Make sure we can derive with no `uses`.
     pub mod no_prelude {

--- a/src/types/src/document/mapping.rs
+++ b/src/types/src/document/mapping.rs
@@ -1,7 +1,7 @@
 /*! Mapping for Elasticsearch document types. */
 
-use serde::ser::SerializeStruct;
 use serde::{
+    ser::SerializeStruct,
     Serialize,
     Serializer,
 };
@@ -122,8 +122,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/document/mod.rs
+++ b/src/types/src/document/mod.rs
@@ -404,11 +404,13 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::{
-        DocumentType,
-        IndexDocumentMapping,
-        StaticIndex,
-        StaticType,
+    pub use super::{
+        impls::{
+            DocumentType,
+            IndexDocumentMapping,
+            StaticIndex,
+            StaticType,
+        },
+        mapping::*,
     };
-    pub use super::mapping::*;
 }

--- a/src/types/src/geo/mapping.rs
+++ b/src/types/src/geo/mapping.rs
@@ -1,7 +1,9 @@
 /*! Common mapping for the Elasticsearch `geo` types. */
 
-use serde;
-use serde::Serialize;
+use serde::{
+    self,
+    Serialize,
+};
 
 /** A unit of measure for distance. */
 pub enum DistanceUnit {

--- a/src/types/src/geo/mod.rs
+++ b/src/types/src/geo/mod.rs
@@ -17,7 +17,9 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::mapping::*;
-    pub use super::point::prelude::*;
-    pub use super::shape::prelude::*;
+    pub use super::{
+        mapping::*,
+        point::prelude::*,
+        shape::prelude::*,
+    };
 }

--- a/src/types/src/geo/point/format.rs
+++ b/src/types/src/geo/point/format.rs
@@ -1,5 +1,7 @@
-use super::mapping::GeoPointMapping;
-use super::Point;
+use super::{
+    mapping::GeoPointMapping,
+    Point,
+};
 use serde::{
     Deserializer,
     Serializer,

--- a/src/types/src/geo/point/formats.rs
+++ b/src/types/src/geo/point/formats.rs
@@ -1,25 +1,27 @@
-use super::mapping::GeoPointMapping;
 use super::{
+    mapping::GeoPointMapping,
     Coordinate,
     GeoPointFormat,
     Point,
 };
 use geo::mapping::Distance;
 use geohash;
-use serde::de::{
-    Error,
-    SeqAccess,
-    Unexpected,
-    Visitor,
-};
 use serde::{
+    de::{
+        Error,
+        SeqAccess,
+        Unexpected,
+        Visitor,
+    },
     Deserialize,
     Deserializer,
     Serialize,
     Serializer,
 };
-use std::fmt::Write;
-use std::str::FromStr;
+use std::{
+    fmt::Write,
+    str::FromStr,
+};
 
 /** The default `geo_point` format (`GeoPointArray`). */
 pub type DefaultGeoPointFormat = GeoPointArray;

--- a/src/types/src/geo/point/impls.rs
+++ b/src/types/src/geo/point/impls.rs
@@ -1,8 +1,8 @@
-use super::mapping::{
-    GeoPointFieldType,
-    GeoPointMapping,
-};
 use super::{
+    mapping::{
+        GeoPointFieldType,
+        GeoPointMapping,
+    },
     Coordinate,
     GeoPointFormat,
     Geometry,
@@ -18,8 +18,10 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+};
 
 /**
 An Elasticsearch `geo_point` type with a format.

--- a/src/types/src/geo/point/mapping.rs
+++ b/src/types/src/geo/point/mapping.rs
@@ -162,8 +162,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/geo/point/mod.rs
+++ b/src/types/src/geo/point/mod.rs
@@ -77,9 +77,11 @@ mod format;
 mod formats;
 mod impls;
 
-pub use self::format::*;
-pub use self::formats::*;
-pub use self::impls::*;
+pub use self::{
+    format::*,
+    formats::*,
+    impls::*,
+};
 
 pub mod prelude {
     /*!
@@ -88,9 +90,11 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::format::*;
-    pub use super::formats::*;
-    pub use super::impls::*;
-    pub use super::mapping::*;
-    pub use super::DefaultGeoPointFormat;
+    pub use super::{
+        format::*,
+        formats::*,
+        impls::*,
+        mapping::*,
+        DefaultGeoPointFormat,
+    };
 }

--- a/src/types/src/geo/shape/impls.rs
+++ b/src/types/src/geo/shape/impls.rs
@@ -9,8 +9,10 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+};
 
 /**
 Geo shape type with a given mapping.

--- a/src/types/src/geo/shape/mapping.rs
+++ b/src/types/src/geo/shape/mapping.rs
@@ -232,8 +232,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/geo/shape/mod.rs
+++ b/src/types/src/geo/shape/mod.rs
@@ -71,6 +71,8 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::*;
-    pub use super::mapping::*;
+    pub use super::{
+        impls::*,
+        mapping::*,
+    };
 }

--- a/src/types/src/ip/impls.rs
+++ b/src/types/src/ip/impls.rs
@@ -3,21 +3,23 @@ use super::mapping::{
     IpFieldType,
     IpMapping,
 };
-use serde::de::{
-    Error,
-    Visitor,
-};
 use serde::{
+    de::{
+        Error,
+        Visitor,
+    },
     Deserialize,
     Deserializer,
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::error::Error as StdError;
-use std::marker::PhantomData;
-use std::net::Ipv4Addr;
-use std::str::FromStr;
+use std::{
+    borrow::Borrow,
+    error::Error as StdError,
+    marker::PhantomData,
+    net::Ipv4Addr,
+    str::FromStr,
+};
 
 impl IpFieldType<DefaultIpMapping> for Ipv4Addr {}
 

--- a/src/types/src/ip/mapping.rs
+++ b/src/types/src/ip/mapping.rs
@@ -117,8 +117,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/ip/mod.rs
+++ b/src/types/src/ip/mod.rs
@@ -65,6 +65,8 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::*;
-    pub use super::mapping::*;
+    pub use super::{
+        impls::*,
+        mapping::*,
+    };
 }

--- a/src/types/src/number/impls.rs
+++ b/src/types/src/number/impls.rs
@@ -5,8 +5,10 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+};
 
 macro_rules! number_type {
     ($wrapper_ty:ident, $mapping_ty:ident, $field_trait:ident, $std_ty:ident) => {

--- a/src/types/src/number/mod.rs
+++ b/src/types/src/number/mod.rs
@@ -78,6 +78,8 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::*;
-    pub use super::mapping::*;
+    pub use super::{
+        impls::*,
+        mapping::*,
+    };
 }

--- a/src/types/src/private/field.rs
+++ b/src/types/src/private/field.rs
@@ -9,9 +9,11 @@ use serde::ser::{
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
-use std::ops::Deref;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+    ops::Deref,
+};
 
 pub trait StaticSerialize {
     fn static_serialize<S>(serializer: S) -> Result<S::Ok, S::Error>

--- a/src/types/src/private/impls.rs
+++ b/src/types/src/private/impls.rs
@@ -1,15 +1,17 @@
-use serde::ser::SerializeStruct;
 use serde::{
+    ser::SerializeStruct,
     Serialize,
     Serializer,
 };
-use std::collections::{
-    BTreeMap,
-    HashMap,
-    HashSet,
+use std::{
+    collections::{
+        BTreeMap,
+        HashMap,
+        HashSet,
+    },
+    hash::Hash,
+    marker::PhantomData,
 };
-use std::hash::Hash;
-use std::marker::PhantomData;
 
 use super::field::{
     FieldMapping,

--- a/src/types/src/string/keyword/impls.rs
+++ b/src/types/src/string/keyword/impls.rs
@@ -2,18 +2,20 @@ use super::mapping::{
     KeywordFieldType,
     KeywordMapping,
 };
-use serde::de::{
-    Error,
-    Visitor,
-};
 use serde::{
+    de::{
+        Error,
+        Visitor,
+    },
     Deserialize,
     Deserializer,
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+};
 
 /**
 An Elasticsearch `keyword` with a mapping.

--- a/src/types/src/string/keyword/mapping.rs
+++ b/src/types/src/string/keyword/mapping.rs
@@ -1,8 +1,8 @@
 /*! Mapping for the Elasticsearch `keyword` type. */
 
 use private::field::FieldMapping;
-use serde::ser::SerializeStruct;
 use serde::{
+    ser::SerializeStruct,
     Serialize,
     Serializer,
 };
@@ -314,8 +314,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/string/keyword/mod.rs
+++ b/src/types/src/string/keyword/mod.rs
@@ -19,6 +19,8 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::*;
-    pub use super::mapping::*;
+    pub use super::{
+        impls::*,
+        mapping::*,
+    };
 }

--- a/src/types/src/string/mapping.rs
+++ b/src/types/src/string/mapping.rs
@@ -1,12 +1,14 @@
 /*! Common mapping for the Elasticsearch `string` types. */
 
-use super::keyword::mapping::KeywordFieldMapping;
-use super::text::mapping::{
-    TextFieldMapping,
-    TextMapping,
+use super::{
+    keyword::mapping::KeywordFieldMapping,
+    text::mapping::{
+        TextFieldMapping,
+        TextMapping,
+    },
 };
-use serde::ser::SerializeStruct;
 use serde::{
+    ser::SerializeStruct,
     Serialize,
     Serializer,
 };

--- a/src/types/src/string/mod.rs
+++ b/src/types/src/string/mod.rs
@@ -89,8 +89,10 @@ pub mod text;
 
 pub mod mapping;
 
-pub use self::keyword::Keyword;
-pub use self::text::Text;
+pub use self::{
+    keyword::Keyword,
+    text::Text,
+};
 
 pub mod prelude {
     /*!
@@ -99,9 +101,11 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::keyword::prelude::*;
-    pub use super::mapping::*;
-    pub use super::text::prelude::*;
+    pub use super::{
+        keyword::prelude::*,
+        mapping::*,
+        text::prelude::*,
+    };
 }
 
 #[cfg(test)]

--- a/src/types/src/string/text/impls.rs
+++ b/src/types/src/string/text/impls.rs
@@ -2,18 +2,20 @@ use super::mapping::{
     TextFieldType,
     TextMapping,
 };
-use serde::de::{
-    Error,
-    Visitor,
-};
 use serde::{
+    de::{
+        Error,
+        Visitor,
+    },
     Deserialize,
     Deserializer,
     Serialize,
     Serializer,
 };
-use std::borrow::Borrow;
-use std::marker::PhantomData;
+use std::{
+    borrow::Borrow,
+    marker::PhantomData,
+};
 use string::mapping::DefaultStringMapping;
 
 impl TextFieldType<DefaultStringMapping> for String {}

--- a/src/types/src/string/text/mapping.rs
+++ b/src/types/src/string/text/mapping.rs
@@ -1,8 +1,8 @@
 /*! Mapping for the Elasticsearch `text` type. */
 
 use private::field::FieldMapping;
-use serde::ser::SerializeStruct;
 use serde::{
+    ser::SerializeStruct,
     Serialize,
     Serializer,
 };
@@ -422,8 +422,8 @@ mod private {
         SerializeFieldMapping,
         StaticSerialize,
     };
-    use serde::ser::SerializeStruct;
     use serde::{
+        ser::SerializeStruct,
         Serialize,
         Serializer,
     };

--- a/src/types/src/string/text/mod.rs
+++ b/src/types/src/string/text/mod.rs
@@ -17,6 +17,8 @@ pub mod prelude {
     This is a convenience module to make it easy to build mappings for multiple types without too many `use` statements.
     */
 
-    pub use super::impls::*;
-    pub use super::mapping::*;
+    pub use super::{
+        impls::*,
+        mapping::*,
+    };
 }

--- a/tests/run/src/build_client.rs
+++ b/tests/run/src/build_client.rs
@@ -1,5 +1,7 @@
-use elastic::prelude::*;
-use elastic::Error;
+use elastic::{
+    prelude::*,
+    Error,
+};
 use std::time::Duration;
 
 pub fn call(run: &str) -> Result<AsyncClient, Error> {

--- a/tests/run/src/build_container.rs
+++ b/tests/run/src/build_container.rs
@@ -1,11 +1,13 @@
-use std::error::Error;
-use std::path::{
-    Path,
-    PathBuf,
-};
-use std::process::{
-    Command,
-    Stdio,
+use std::{
+    error::Error,
+    path::{
+        Path,
+        PathBuf,
+    },
+    process::{
+        Command,
+        Stdio,
+    },
 };
 
 struct Names {

--- a/tests/run/src/bulk/delete.rs
+++ b/tests/run/src/bulk/delete.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/bulk/index_create.rs
+++ b/tests/run/src/bulk/index_create.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/bulk/index_get.rs
+++ b/tests/run/src/bulk/index_get.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/bulk/raw_index_create.rs
+++ b/tests/run/src/bulk/raw_index_create.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 
@@ -44,11 +46,15 @@ impl IntegrationTest for RawIndexCreate {
 
     // Index a document, then get it
     fn request(&self, client: AsyncClient) -> Box<Future<Item = Self::Response, Error = Error>> {
-        let bulk_res = client.bulk().push(bulk_raw()
-            .create(doc())
-            .index(INDEX)
-            .ty(Doc::static_ty())
-            .id(ID))
+        let bulk_res = client
+            .bulk()
+            .push(
+                bulk_raw()
+                    .create(doc())
+                    .index(INDEX)
+                    .ty(Doc::static_ty())
+                    .id(ID),
+            )
             .send();
 
         Box::new(bulk_res)

--- a/tests/run/src/bulk/raw_index_get.rs
+++ b/tests/run/src/bulk/raw_index_get.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/bulk/stream.rs
+++ b/tests/run/src/bulk/stream.rs
@@ -1,6 +1,8 @@
-use elastic::client::responses::bulk::OkItem;
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    client::responses::bulk::OkItem,
+    error::Error,
+    prelude::*,
+};
 use futures::{
     stream,
     Future,

--- a/tests/run/src/bulk/stream_tiny_size_limit.rs
+++ b/tests/run/src/bulk/stream_tiny_size_limit.rs
@@ -1,6 +1,8 @@
-use elastic::client::responses::bulk::OkItem;
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    client::responses::bulk::OkItem,
+    error::Error,
+    prelude::*,
+};
 use futures::{
     stream,
     Future,

--- a/tests/run/src/bulk/stream_tiny_timeout.rs
+++ b/tests/run/src/bulk/stream_tiny_timeout.rs
@@ -1,6 +1,8 @@
-use elastic::client::responses::bulk::OkItem;
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    client::responses::bulk::OkItem,
+    error::Error,
+    prelude::*,
+};
 use futures::{
     stream,
     Future,

--- a/tests/run/src/bulk/stream_zero_size_limit.rs
+++ b/tests/run/src/bulk/stream_zero_size_limit.rs
@@ -1,6 +1,8 @@
-use elastic::client::responses::bulk::OkItem;
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    client::responses::bulk::OkItem,
+    error::Error,
+    prelude::*,
+};
 use futures::{
     stream,
     Future,

--- a/tests/run/src/document/delete.rs
+++ b/tests/run/src/document/delete.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/document/simple_index_get.rs
+++ b/tests/run/src/document/simple_index_get.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/document/simple_mapping.rs
+++ b/tests/run/src/document/simple_mapping.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/document/update_no_index.rs
+++ b/tests/run/src/document/update_no_index.rs
@@ -1,8 +1,10 @@
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/document/update_with_doc.rs
+++ b/tests/run/src/document/update_with_doc.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/document/update_with_inline_script.rs
+++ b/tests/run/src/document/update_with_inline_script.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/document/update_with_script.rs
+++ b/tests/run/src/document/update_with_script.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/index/does_not_exist.rs
+++ b/tests/run/src/index/does_not_exist.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/index/exists.rs
+++ b/tests/run/src/index/exists.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/main.rs
+++ b/tests/run/src/main.rs
@@ -27,8 +27,10 @@ use clap::{
     Arg,
 };
 use std::process;
-use term_painter::Color::*;
-use term_painter::ToStyle;
+use term_painter::{
+    Color::*,
+    ToStyle,
+};
 
 mod build_client;
 mod build_container;

--- a/tests/run/src/run_tests.rs
+++ b/tests/run/src/run_tests.rs
@@ -1,17 +1,21 @@
 use std::fmt::Debug;
 
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use futures::{
     stream,
     Future,
     Stream,
 };
-use term_painter::Color::*;
-use term_painter::ToStyle;
+use term_painter::{
+    Color::*,
+    ToStyle,
+};
 
 pub type TestResult = bool;
 pub type Test = Box<Fn(AsyncClient) -> Box<Future<Item = TestResult, Error = ()>>>;

--- a/tests/run/src/search/empty_query.rs
+++ b/tests/run/src/search/empty_query.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::{
     future,
     Future,

--- a/tests/run/src/search/no_index.rs
+++ b/tests/run/src/search/no_index.rs
@@ -1,8 +1,10 @@
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use futures::Future;
 use run_tests::IntegrationTest;
 use serde_json::Value;

--- a/tests/run/src/search/raw_query_string.rs
+++ b/tests/run/src/search/raw_query_string.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::{
     future,
     Future,

--- a/tests/run/src/sql/invalid_query.rs
+++ b/tests/run/src/sql/invalid_query.rs
@@ -1,8 +1,10 @@
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use futures::Future;
 use run_tests::IntegrationTest;
 

--- a/tests/run/src/sql/invalid_syntax.rs
+++ b/tests/run/src/sql/invalid_syntax.rs
@@ -1,8 +1,10 @@
-use elastic::error::{
-    ApiError,
-    Error,
+use elastic::{
+    error::{
+        ApiError,
+        Error,
+    },
+    prelude::*,
 };
-use elastic::prelude::*;
 use futures::{
     future,
     Future,

--- a/tests/run/src/sql/select_all.rs
+++ b/tests/run/src/sql/select_all.rs
@@ -1,5 +1,7 @@
-use elastic::error::Error;
-use elastic::prelude::*;
+use elastic::{
+    error::Error,
+    prelude::*,
+};
 use futures::{
     future,
     Future,

--- a/tests/run/src/wait_until_ready.rs
+++ b/tests/run/src/wait_until_ready.rs
@@ -4,9 +4,11 @@ use futures::{
     Future,
     Stream,
 };
-use std::error::Error as StdError;
-use std::fmt;
-use std::time::Duration;
+use std::{
+    error::Error as StdError,
+    fmt,
+    time::Duration,
+};
 
 type Error = Box<StdError>;
 


### PR DESCRIPTION
Fixes #358 

It's a bit unfortunate that we need to add so many defensive bounds, but making the synchronous client also require `Send` means we could offload work while still being synchronous if we want.

Depends on https://github.com/KodrAus/fluent_builder/pull/6