### PR TITLE
Add support for _seq_no & _primary_term in responses

### DIFF
--- a/src/elastic/src/client/responses/bulk.rs
+++ b/src/elastic/src/client/responses/bulk.rs
@@ -420,6 +420,8 @@ pub struct OkItem<
     ty: TType,
     id: TId,
     version: Option<u32>,
+    sequence_number: Option<u32>,
+    primary_term: Option<u32>,
     shards: Option<Shards>,
     result: Option<DocumentResult>,
 }
@@ -433,6 +435,24 @@ impl<TIndex, TType, TId> OkItem<TIndex, TType, TId> {
     /** The document version after this item. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
+    }
+
+    /**
+     * The [sequence number] of the document.
+     *
+     * [sequence number]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn sequence_number(&self) -> Option<u32> {
+        self.sequence_number.clone()
+    }
+
+    /**
+     * The [primary term] of the document.
+     *
+     * [primary term]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn primary_term(&self) -> Option<u32> {
+        self.primary_term.clone()
     }
 
     /**
@@ -584,6 +604,10 @@ struct ItemDeInner<TIndex, TType, TId> {
     id: TId,
     #[serde(rename = "_version")]
     version: Option<u32>,
+    #[serde(rename = "_seq_no")]
+    sequence_number: Option<u32>,
+    #[serde(rename = "_primary_term")]
+    primary_term: Option<u32>,
     #[serde(rename = "_shards")]
     shards: Option<Shards>,
     result: Option<DocumentResult>,
@@ -620,6 +644,8 @@ where
                 ty: self.inner.ty,
                 id: self.inner.id,
                 version: self.inner.version,
+                sequence_number: self.inner.sequence_number,
+                primary_term: self.inner.primary_term,
                 shards: self.inner.shards,
                 result: self.inner.result,
             })

--- a/src/elastic/src/client/responses/document_delete.rs
+++ b/src/elastic/src/client/responses/document_delete.rs
@@ -34,6 +34,10 @@ pub struct DeleteResponse {
     id: String,
     #[serde(rename = "_version")]
     version: Option<u32>,
+    #[serde(rename = "_seq_no")]
+    sequence_number: Option<u32>,
+    #[serde(rename = "_primary_term")]
+    primary_term: Option<u32>,
     #[serde(rename = "_routing")]
     routing: Option<String>,
     result: DocumentResult,
@@ -66,6 +70,24 @@ impl DeleteResponse {
     /** The version of the document. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
+    }
+
+    /**
+     * The [sequence number] of the document.
+     *
+     * [sequence number]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn sequence_number(&self) -> Option<u32> {
+        self.sequence_number.clone()
+    }
+
+    /**
+     * The [primary term] of the document.
+     *
+     * [primary term]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn primary_term(&self) -> Option<u32> {
+        self.primary_term.clone()
     }
 }
 

--- a/src/elastic/src/client/responses/document_get.rs
+++ b/src/elastic/src/client/responses/document_get.rs
@@ -32,6 +32,10 @@ pub struct GetResponse<T> {
     id: String,
     #[serde(rename = "_version")]
     version: Option<u32>,
+    #[serde(rename = "_seq_no")]
+    sequence_number: Option<u32>,
+    #[serde(rename = "_primary_term")]
+    primary_term: Option<u32>,
     found: bool,
     #[serde(rename = "_source")]
     source: Option<T>,
@@ -73,6 +77,24 @@ impl<T> GetResponse<T> {
     /** The version of the document. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
+    }
+
+    /**
+     * The [sequence number] of the document.
+     *
+     * [sequence number]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn sequence_number(&self) -> Option<u32> {
+        self.sequence_number.clone()
+    }
+
+    /**
+     * The [primary term] of the document.
+     *
+     * [primary term]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn primary_term(&self) -> Option<u32> {
+        self.primary_term.clone()
     }
 }
 

--- a/src/elastic/src/client/responses/document_index.rs
+++ b/src/elastic/src/client/responses/document_index.rs
@@ -27,6 +27,10 @@ pub struct IndexResponse {
     id: String,
     #[serde(rename = "_version")]
     version: Option<u32>,
+    #[serde(rename = "_seq_no")]
+    sequence_number: Option<u32>,
+    #[serde(rename = "_primary_term")]
+    primary_term: Option<u32>,
     result: DocumentResult,
     #[serde(rename = "_shards")]
     shards: Shards,
@@ -64,6 +68,24 @@ impl IndexResponse {
     /** The version of the document. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
+    }
+
+    /**
+     * The [sequence number] of the document.
+     *
+     * [sequence number]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn sequence_number(&self) -> Option<u32> {
+        self.sequence_number.clone()
+    }
+
+    /**
+     * The [primary term] of the document.
+     *
+     * [primary term]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn primary_term(&self) -> Option<u32> {
+        self.primary_term.clone()
     }
 }
 

--- a/src/elastic/src/client/responses/document_update.rs
+++ b/src/elastic/src/client/responses/document_update.rs
@@ -24,6 +24,10 @@ pub struct UpdateResponse {
     id: String,
     #[serde(rename = "_version")]
     version: Option<u32>,
+    #[serde(rename = "_seq_no")]
+    sequence_number: Option<u32>,
+    #[serde(rename = "_primary_term")]
+    primary_term: Option<u32>,
     #[serde(rename = "_routing")]
     routing: Option<String>,
     result: DocumentResult,
@@ -56,6 +60,24 @@ impl UpdateResponse {
     /** The version of the document. */
     pub fn version(&self) -> Option<u32> {
         self.version.clone()
+    }
+
+    /**
+     * The [sequence number] of the document.
+     *
+     * [sequence number]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn sequence_number(&self) -> Option<u32> {
+        self.sequence_number.clone()
+    }
+
+    /**
+     * The [primary term] of the document.
+     *
+     * [primary term]: https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html
+     */
+    pub fn primary_term(&self) -> Option<u32> {
+        self.primary_term.clone()
     }
 }
 


### PR DESCRIPTION
Add `sequence_number` and `primary_term` fields/methods to all the things.

Questions:
- Should we name it `seq_no` instead of `sequence_number`?
- Should we link to the [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html) docs?