### PR TITLE
Add support for _source on update requests

### DIFF
--- a/src/elastic/examples/update_with_source.rs
+++ b/src/elastic/examples/update_with_source.rs
@@ -1,0 +1,79 @@
+//! Update a document and return the updated document in a single request.
+//!
+//! NOTE: This sample expects you have a node running on `localhost:9200`.
+//!
+//! This sample demonstrates how to index & update a document and return
+//! the newly updated document.
+//! Also see the `typed` sample for a more complete implementation.
+
+use std::error::Error;
+
+use elastic::prelude::*;
+use elastic_derive::ElasticType;
+use env_logger;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[derive(Debug, Serialize, Deserialize, ElasticType)]
+#[elastic(index = "update_with_source_sample_index")]
+struct NewsArticle {
+    #[elastic(id)]
+    id: String,
+    title: String,
+    content: String,
+    likes: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ElasticType)]
+#[elastic(index = "update_with_source_sample_index")]
+struct UpdatedNewsArticle {
+    #[elastic(id)]
+    id: String,
+    title: String,
+    content: String,
+    likes: i64,
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    // A HTTP client and request parameters
+    let client = SyncClient::builder().build()?;
+
+    // Create a document to index
+    let doc = NewsArticle {
+        id: "1".to_string(),
+        title: "A title".to_string(),
+        content: "Some content.".to_string(),
+        likes: 0,
+    };
+
+    // Index the document
+    client.document().index(doc).send()?;
+
+    // Update the document using a script
+    let update = client
+        .document::<NewsArticle>()
+        .update("1")
+        .script("ctx._source.likes++")
+        // Request that the updated document be returned with the response
+        .source::<UpdatedNewsArticle>()
+        .send()?;
+
+    assert!(update.updated());
+
+    // Deserialize the updated document to the type we requested earlier;
+    // this will return `None` if `source()` was not called on the request
+    let updated_doc = update.into_document().unwrap();
+
+    assert!(updated_doc.likes > 0);
+
+    println!("{:#?}", &updated_doc);
+
+    Ok(())
+}
+
+fn main() {
+    env_logger::init();
+    run().unwrap()
+}

--- a/src/elastic/examples/update_with_source.rs
+++ b/src/elastic/examples/update_with_source.rs
@@ -57,14 +57,14 @@ fn run() -> Result<(), Box<dyn Error>> {
         .update("1")
         .script("ctx._source.likes++")
         // Request that the updated document be returned with the response
-        .source::<UpdatedNewsArticle>()
+        .source()
         .send()?;
 
     assert!(update.updated());
 
-    // Deserialize the updated document to the type we requested earlier;
-    // this will return `None` if `source()` was not called on the request
-    let updated_doc = update.into_document().unwrap();
+    // Deserialize the updated document,
+    // will return `None` if `source()` was not called on the request
+    let updated_doc = update.into_document::<UpdatedNewsArticle>().unwrap();
 
     assert!(updated_doc.likes > 0);
 

--- a/tests/integration/src/tests/document/mod.rs
+++ b/tests/integration/src/tests/document/mod.rs
@@ -5,7 +5,8 @@ test_cases![
     update_no_index,
     update_with_doc,
     update_with_inline_script,
-    update_with_script
+    update_with_script,
+    update_with_source
 ];
 
 mod compile_test;

--- a/tests/integration/src/tests/document/update_with_source.rs
+++ b/tests/integration/src/tests/document/update_with_source.rs
@@ -33,7 +33,7 @@ fn doc() -> Doc {
 test! {
     const description: &'static str = "update and return source";
 
-    type Response = UpdateResponse<UpdatedDoc>;
+    type Response = UpdateResponse;
 
     // Ensure the index doesn't exist
     fn prepare(&self, client: AsyncClient) -> Box<dyn Future<Item = (), Error = Error>> {
@@ -64,7 +64,7 @@ test! {
             .doc(json!({
                 "title": EXPECTED_TITLE.to_owned(),
             }))
-            .source::<UpdatedDoc>()
+            .source()
             .send();
 
         Box::new(
@@ -78,7 +78,7 @@ test! {
     fn assert_ok(&self, res: &Self::Response) -> bool {
         let updated = res.updated();
         let correct_version = res.version() == Some(2);
-        let correct_title = res.into_document().unwrap().title == EXPECTED_TITLE;
+        let correct_title = res.into_document::<UpdatedDoc>().unwrap().title == EXPECTED_TITLE;
 
         updated && correct_version && correct_title
     }

--- a/tests/integration/src/tests/document/update_with_source.rs
+++ b/tests/integration/src/tests/document/update_with_source.rs
@@ -1,0 +1,85 @@
+use elastic::{
+    error::Error,
+    prelude::*,
+};
+use futures::Future;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, ElasticType)]
+#[elastic(index = "update_doc_source_idx")]
+pub struct Doc {
+    #[elastic(id)]
+    id: String,
+    title: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize, ElasticType)]
+#[elastic(index = "update_doc_source_idx")]
+pub struct UpdatedDoc {
+    #[elastic(id)]
+    id: String,
+    title: String,
+}
+
+const EXPECTED_TITLE: &'static str = "Edited title";
+const ID: &'static str = "1";
+
+fn doc() -> Doc {
+    Doc {
+        id: ID.to_owned(),
+        title: "Not edited title".to_owned(),
+    }
+}
+
+test! {
+    const description: &'static str = "update and return source";
+
+    type Response = UpdateResponse<UpdatedDoc>;
+
+    // Ensure the index doesn't exist
+    fn prepare(&self, client: AsyncClient) -> Box<dyn Future<Item = (), Error = Error>> {
+        let delete_res = client
+            .index(Doc::static_index())
+            .delete()
+            .send()
+            .map(|_| ());
+
+        Box::new(delete_res)
+    }
+
+    // Execute an update request against that index using a new document & request
+    // that the updated document's `source` be returned with the response.
+    fn request(
+        &self,
+        client: AsyncClient,
+    ) -> Box<dyn Future<Item = Self::Response, Error = Error>> {
+        let index_res = client
+            .document()
+            .index(doc())
+            .params_fluent(|p| p.url_param("refresh", true))
+            .send();
+
+        let update_res = client
+            .document::<Doc>()
+            .update(ID)
+            .doc(json!({
+                "title": EXPECTED_TITLE.to_owned(),
+            }))
+            .source::<UpdatedDoc>()
+            .send();
+
+        Box::new(
+            index_res
+                .and_then(|_| update_res)
+                .map(|update| update)
+        )
+    }
+
+    // Ensure the response contains the expected document
+    fn assert_ok(&self, res: &Self::Response) -> bool {
+        let updated = res.updated();
+        let correct_version = res.version() == Some(2);
+        let correct_title = res.into_document().unwrap().title == EXPECTED_TITLE;
+
+        updated && correct_version && correct_title
+    }
+}


### PR DESCRIPTION
In order to maintain backwards compatibility by not introducing a new generic parameter on `UpdateResponse`, I had to use `serde_json::Value` as an intermediate value... 

If we are ok with not maintaining backwards compatibility I can update this PR and introduce a new generic parameter, which will result in something like this: `UpdateRequestBuilder<TSender, TBody, TDocument>`.

As a result, as of right now, you use this like:

```rust
#[derive(Deserialize, ElasticType, Debug)]
struct User {
    #[elastic(id)]
    id: String,
    name: String,
}

#[derive(Serialize, ElasticType, Debug)]
struct UpdateUser {
    #[elastic(id)]
    id: String,
    #[serde(skip_serializing_if = "Option::is_none")]
    name: Option<String>,
}
```

```rust
let response = client
    .document::<UpdateUser>()
    .update(1)
    .script(r#"ctx._source.name = "Updated Name""#)
    .params_fluent(|params| params.url_param("_source", true))
    .send()?;

dbg!(&response.into_document::<User>());
``` 

I am hoping to tackle `bulk` updates ASAP too...