### PR TITLE
Update syn, quote & serde_derive_internals dependencies

### DIFF
--- a/src/elastic/src/types/document/impls.rs
+++ b/src/elastic/src/types/document/impls.rs
@@ -336,7 +336,6 @@ mod tests {
     }
 
     impl CustomType {
-        #[allow(dead_code)]
         fn id(&self) -> String {
             self.field.to_string()
         }

--- a/src/elastic/src/types/document/impls.rs
+++ b/src/elastic/src/types/document/impls.rs
@@ -336,6 +336,7 @@ mod tests {
     }
 
     impl CustomType {
+        #[allow(dead_code)]
         fn id(&self) -> String {
             self.field.to_string()
         }

--- a/src/elastic_derive/Cargo.toml
+++ b/src/elastic_derive/Cargo.toml
@@ -13,9 +13,10 @@ proc-macro = true
 [dependencies]
 serde = "~1"
 serde_json = "~1"
-syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
-quote = "~0.3.0"
-serde_derive_internals = { version = "~0.15.0", default-features = false }
+proc-macro2 = "~1"
+syn = { version = "~1", features = ["visit", "parsing", "full"] }
+quote = "~1"
+serde_derive_internals = { version = "~0.25", default-features = false }
 quick-error = "~1"
 nom = "~3"
 chrono = { version = "~0.4.0", features = [ "serde" ]}

--- a/src/elastic_derive/src/date_format/mod.rs
+++ b/src/elastic_derive/src/date_format/mod.rs
@@ -1,4 +1,8 @@
-use syn;
+use syn::{
+    Data,
+    DeriveInput,
+    Fields,
+};
 
 mod parse;
 
@@ -18,12 +22,12 @@ The input must satisfy the following rules:
 */
 pub fn expand_derive(
     crate_root: proc_macro2::TokenStream,
-    input: &syn::DeriveInput,
+    input: &DeriveInput,
 ) -> Result<Vec<proc_macro2::TokenStream>, DeriveDateFormatError> {
     // Annotatable item for a unit struct
     match input.data {
-        syn::Data::Struct(ref data) => match data.fields {
-            syn::Fields::Unit => Ok(()),
+        Data::Struct(ref data) => match data.fields {
+            Fields::Unit => Ok(()),
             _ => Err(DeriveDateFormatError::InvalidInput),
         },
         _ => Err(DeriveDateFormatError::InvalidInput),
@@ -46,7 +50,7 @@ pub fn expand_derive(
 // Implement DateFormat for the type being derived with the mapping
 fn impl_date_format(
     crate_root: proc_macro2::TokenStream,
-    item: &syn::DeriveInput,
+    item: &DeriveInput,
     name: &str,
     format: &[proc_macro2::TokenStream],
 ) -> proc_macro2::TokenStream {
@@ -86,7 +90,7 @@ fn impl_date_format(
 }
 
 // Get the format string supplied by an #[elastic()] attribute
-fn get_format_from_attr<'a>(item: &'a syn::DeriveInput) -> Option<String> {
+fn get_format_from_attr<'a>(item: &'a DeriveInput) -> Option<String> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val
@@ -98,7 +102,7 @@ fn get_format_from_attr<'a>(item: &'a syn::DeriveInput) -> Option<String> {
 }
 
 // Get the name string supplied by an #[elastic()] attribute
-fn get_name_from_attr<'a>(item: &'a syn::DeriveInput) -> Option<String> {
+fn get_name_from_attr<'a>(item: &'a DeriveInput) -> Option<String> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val

--- a/src/elastic_derive/src/date_format/mod.rs
+++ b/src/elastic_derive/src/date_format/mod.rs
@@ -1,4 +1,3 @@
-use quote::Tokens;
 use syn;
 
 mod parse;
@@ -6,7 +5,7 @@ mod parse;
 use super::{
     expect_name_value,
     get_elastic_meta_items,
-    get_str_from_lit,
+    get_string_from_lit,
 };
 
 /**
@@ -18,13 +17,13 @@ The input must satisfy the following rules:
 - It must have an `#[elastic(date_format="<value>")]` attribute.
 */
 pub fn expand_derive(
-    crate_root: Tokens,
-    input: &syn::MacroInput,
-) -> Result<Vec<Tokens>, DeriveDateFormatError> {
+    crate_root: proc_macro2::TokenStream,
+    input: &syn::DeriveInput,
+) -> Result<Vec<proc_macro2::TokenStream>, DeriveDateFormatError> {
     // Annotatable item for a unit struct
-    match input.body {
-        syn::Body::Struct(ref data) => match *data {
-            syn::VariantData::Unit => Ok(()),
+    match input.data {
+        syn::Data::Struct(ref data) => match data.fields {
+            syn::Fields::Unit => Ok(()),
             _ => Err(DeriveDateFormatError::InvalidInput),
         },
         _ => Err(DeriveDateFormatError::InvalidInput),
@@ -34,7 +33,7 @@ pub fn expand_derive(
 
     let name = get_name_from_attr(input).unwrap_or_else(|| format.clone());
 
-    let tokens: Vec<Tokens> = parse::to_tokens(&format)?
+    let tokens: Vec<proc_macro2::TokenStream> = parse::to_tokens(&format)?
         .into_iter()
         .map(|t| t.into_tokens(&crate_root))
         .collect();
@@ -46,11 +45,11 @@ pub fn expand_derive(
 
 // Implement DateFormat for the type being derived with the mapping
 fn impl_date_format(
-    crate_root: Tokens,
-    item: &syn::MacroInput,
+    crate_root: proc_macro2::TokenStream,
+    item: &syn::DeriveInput,
     name: &str,
-    format: &[Tokens],
-) -> Tokens {
+    format: &[proc_macro2::TokenStream],
+) -> proc_macro2::TokenStream {
     let ty = &item.ident;
 
     let parse_fn = quote!(
@@ -87,7 +86,7 @@ fn impl_date_format(
 }
 
 // Get the format string supplied by an #[elastic()] attribute
-fn get_format_from_attr<'a>(item: &'a syn::MacroInput) -> Option<String> {
+fn get_format_from_attr<'a>(item: &'a syn::DeriveInput) -> Option<String> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val
@@ -95,11 +94,11 @@ fn get_format_from_attr<'a>(item: &'a syn::MacroInput) -> Option<String> {
         .filter_map(|meta| expect_name_value("date_format", &meta))
         .next();
 
-    val.and_then(|v| get_str_from_lit(v).ok().map(Into::into))
+    val.and_then(|v| get_string_from_lit(v).ok().map(Into::into))
 }
 
 // Get the name string supplied by an #[elastic()] attribute
-fn get_name_from_attr<'a>(item: &'a syn::MacroInput) -> Option<String> {
+fn get_name_from_attr<'a>(item: &'a syn::DeriveInput) -> Option<String> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val
@@ -107,11 +106,11 @@ fn get_name_from_attr<'a>(item: &'a syn::MacroInput) -> Option<String> {
         .filter_map(|meta| expect_name_value("date_format_name", &meta))
         .next();
 
-    val.and_then(|v| get_str_from_lit(v).ok().map(Into::into))
+    val.and_then(|v| get_string_from_lit(v).ok().map(Into::into))
 }
 
 impl<'a> parse::DateFormatToken<'a> {
-    fn into_tokens(self, crate_root: &Tokens) -> Tokens {
+    fn into_tokens(self, crate_root: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
         use self::parse::DateFormatToken::*;
 
         match self {

--- a/src/elastic_derive/src/elastic_type/mod.rs
+++ b/src/elastic_derive/src/elastic_type/mod.rs
@@ -6,7 +6,6 @@ use super::{
     get_ident_from_lit,
     get_tokens_from_lit,
 };
-use quote::Tokens;
 use serde_derive_internals::{
     self,
     attr as serde_attr,
@@ -15,8 +14,8 @@ use syn;
 
 struct ElasticDocumentMapping {
     ident: syn::Ident,
-    definition: Tokens,
-    impl_block: Tokens,
+    definition: proc_macro2::TokenStream,
+    impl_block: proc_macro2::TokenStream,
 }
 
 /**
@@ -30,19 +29,17 @@ The input must satisfy the following rules:
 but not `PropertiesMapping`.
 */
 pub fn expand_derive(
-    crate_root: Tokens,
-    input: &syn::MacroInput,
-) -> Result<Vec<Tokens>, DeriveElasticTypeError> {
+    crate_root: proc_macro2::TokenStream,
+    input: &syn::DeriveInput,
+) -> Result<Vec<proc_macro2::TokenStream>, DeriveElasticTypeError> {
     // Annotatable item for a struct with struct fields
-    let fields = match input.body {
-        syn::Body::Struct(ref data) => match *data {
-            syn::VariantData::Struct(ref fields) => Some(fields),
-            _ => None,
-        },
-        _ => None,
-    };
-
-    let fields = fields.ok_or(DeriveElasticTypeError::InvalidInput)?;
+    let fields = match &input.data {
+        syn::Data::Struct(syn::DataStruct {
+            fields: syn::Fields::Named(fields),
+            ..
+        }) => Ok(&fields.named),
+        _ => Err(DeriveElasticTypeError::InvalidInput),
+    }?;
 
     // Get the serializable fields
     let fields: Vec<(syn::Ident, &syn::Field)> = fields
@@ -58,7 +55,7 @@ pub fn expand_derive(
 
     let props_impl_block = get_props_impl_block(&crate_root, &input.ident, &fields);
 
-    let dummy_wrapper = syn::Ident::new(format!("_IMPL_EASTIC_TYPE_FOR_{}", input.ident));
+    let dummy_wrapper = quote::format_ident!("_IMPL_EASTIC_TYPE_FOR_{}", input.ident);
 
     let mapping_definition = &mapping.definition;
     let mapping_impl_block = &mapping.impl_block;
@@ -78,9 +75,12 @@ pub fn expand_derive(
     )])
 }
 
-fn get_mapping(crate_root: &Tokens, input: &syn::MacroInput) -> ElasticDocumentMapping {
+fn get_mapping(
+    crate_root: &proc_macro2::TokenStream,
+    input: &syn::DeriveInput,
+) -> ElasticDocumentMapping {
     // Define a struct for the mapping with a few defaults
-    fn define_mapping(vis: &syn::Visibility, name: &syn::Ident) -> Tokens {
+    fn define_mapping(vis: &syn::Visibility, name: &syn::Ident) -> proc_macro2::TokenStream {
         quote!(
             #[derive(Default, Clone, Copy, Debug)]
             #vis struct #name;
@@ -88,12 +88,12 @@ fn get_mapping(crate_root: &Tokens, input: &syn::MacroInput) -> ElasticDocumentM
     }
 
     // Get the default mapping name
-    fn get_default_mapping(item: &syn::MacroInput) -> syn::Ident {
-        syn::Ident::from(format!("{}Mapping", item.ident))
+    fn get_default_mapping(item: &syn::DeriveInput) -> syn::Ident {
+        quote::format_ident!("{}Mapping", &item.ident)
     }
 
     // Get the mapping ident supplied by an #[elastic()] attribute or create a default one
-    fn get_mapping_from_attr(item: &syn::MacroInput) -> Option<syn::Ident> {
+    fn get_mapping_from_attr(item: &syn::DeriveInput) -> Option<syn::Ident> {
         let val = get_elastic_meta_items(&item.attrs);
 
         let val = val
@@ -106,10 +106,10 @@ fn get_mapping(crate_root: &Tokens, input: &syn::MacroInput) -> ElasticDocumentM
 
     // Implement DocumentMapping for the mapping
     fn impl_document_mapping(
-        crate_root: &Tokens,
+        crate_root: &proc_macro2::TokenStream,
         mapping: &syn::Ident,
         properties: &syn::Ident,
-    ) -> Tokens {
+    ) -> proc_macro2::TokenStream {
         quote!(
             impl #crate_root::__derive::ObjectMapping for #mapping {
                 type Properties = #properties;
@@ -120,8 +120,8 @@ fn get_mapping(crate_root: &Tokens, input: &syn::MacroInput) -> ElasticDocumentM
     if let Some(ident) = get_mapping_from_attr(input) {
         ElasticDocumentMapping {
             ident,
-            definition: Tokens::new(),
-            impl_block: Tokens::new(),
+            definition: proc_macro2::TokenStream::new(),
+            impl_block: proc_macro2::TokenStream::new(),
         }
     } else {
         let ident = get_default_mapping(input);
@@ -138,42 +138,42 @@ fn get_mapping(crate_root: &Tokens, input: &syn::MacroInput) -> ElasticDocumentM
 
 // Implement DocumentType for the type being derived with the mapping
 fn get_doc_ty_impl_block(
-    crate_root: &Tokens,
-    item: &syn::MacroInput,
+    crate_root: &proc_macro2::TokenStream,
+    item: &syn::DeriveInput,
     fields: &[(syn::Ident, &syn::Field)],
     mapping: &syn::Ident,
-) -> Tokens {
+) -> proc_macro2::TokenStream {
     struct MetadataBlock {
-        instance_methods: Tokens,
-        static_impls: Tokens,
+        instance_methods: proc_macro2::TokenStream,
+        static_impls: proc_macro2::TokenStream,
     }
 
     // Implement DocumentMetadata for the type being derived with the mapping
     fn get_doc_ty_methods(
-        crate_root: &Tokens,
-        item: &syn::MacroInput,
+        crate_root: &proc_macro2::TokenStream,
+        item: &syn::DeriveInput,
         fields: &[(syn::Ident, &syn::Field)],
     ) -> MetadataBlock {
         struct ElasticMetadataMethods {
-            index: Tokens,
+            index: proc_macro2::TokenStream,
             index_is_static: bool,
-            ty: Tokens,
+            ty: proc_macro2::TokenStream,
             ty_is_static: bool,
-            id: Tokens,
+            id: proc_macro2::TokenStream,
         }
 
         // Get the default method blocks for `DocumentType`
         fn get_doc_type_methods(
-            crate_root: &Tokens,
-            item: &syn::MacroInput,
+            crate_root: &proc_macro2::TokenStream,
+            item: &syn::DeriveInput,
             fields: &[(syn::Ident, &syn::Field)],
         ) -> ElasticMetadataMethods {
             // Get the default name for the indexed elasticsearch type name
-            fn get_elastic_type_name(item: &syn::MacroInput) -> syn::Lit {
-                syn::Lit::Str(
-                    format!("{}", item.ident).to_lowercase(),
-                    syn::StrStyle::Cooked,
-                )
+            fn get_elastic_type_name(item: &syn::DeriveInput) -> syn::Lit {
+                syn::Lit::Str(syn::LitStr::new(
+                    &format!("{}", item.ident).to_lowercase(),
+                    proc_macro2::Span::call_site(),
+                ))
             }
 
             let (index, index_is_static) = {
@@ -326,20 +326,23 @@ fn get_doc_ty_impl_block(
 
 // Implement PropertiesMapping for the mapping
 fn get_props_impl_block(
-    crate_root: &Tokens,
+    crate_root: &proc_macro2::TokenStream,
     props_ty: &syn::Ident,
     fields: &[(syn::Ident, &syn::Field)],
-) -> Tokens {
+) -> proc_macro2::TokenStream {
     // Get the serde serialisation statements for each of the fields on the type being derived
     fn get_field_ser_stmts(
-        crate_root: &Tokens,
+        crate_root: &proc_macro2::TokenStream,
         fields: &[(syn::Ident, &syn::Field)],
-    ) -> Vec<Tokens> {
-        let fields: Vec<Tokens> = fields
+    ) -> Vec<proc_macro2::TokenStream> {
+        let fields: Vec<proc_macro2::TokenStream> = fields
             .iter()
             .cloned()
             .map(|(name, field)| {
-                let lit = syn::Lit::Str(name.as_ref().to_string(), syn::StrStyle::Cooked);
+                let lit = syn::Lit::Str(syn::LitStr::new(
+                    &name.to_string(),
+                    proc_macro2::Span::call_site(),
+                ));
                 let ty = &field.ty;
 
                 quote!(#crate_root::__derive::field_ser::<#ty, _, _, _>(state, #lit)?;)
@@ -367,7 +370,8 @@ fn get_props_impl_block(
 
 fn get_ser_field(field: &syn::Field) -> Option<(syn::Ident, &syn::Field)> {
     let ctxt = serde_derive_internals::Ctxt::new();
-    let serde_field = serde_attr::Field::from_ast(&ctxt, 0, field);
+    let serde_field =
+        serde_attr::Field::from_ast(&ctxt, 0, field, None, &serde_attr::Default::None);
 
     // If the `serde` parse fails, return `None` and let `serde` panic later
     match ctxt.check() {
@@ -381,7 +385,10 @@ fn get_ser_field(field: &syn::Field) -> Option<(syn::Ident, &syn::Field)> {
     }
 
     Some((
-        syn::Ident::from(serde_field.name().serialize_name().as_ref()),
+        proc_macro2::Ident::new(
+            serde_field.name().serialize_name().as_ref(),
+            proc_macro2::Span::call_site(),
+        ),
         field,
     ))
 }
@@ -396,20 +403,20 @@ quick_error! {
 }
 
 enum MethodFromStruct {
-    Literal(Tokens),
-    Expr(Tokens),
+    Literal(proc_macro2::TokenStream),
+    Expr(proc_macro2::TokenStream),
 }
 
 enum MethodFromField {
-    Field(Tokens),
-    Literal(Tokens, Tokens),
-    Expr(Tokens, Tokens),
+    Field(proc_macro2::TokenStream),
+    Literal(proc_macro2::TokenStream, proc_macro2::TokenStream),
+    Expr(proc_macro2::TokenStream, proc_macro2::TokenStream),
 }
 
 // Get the mapping ident supplied by an #[elastic()] attribute or create a default one
 // Parses #[elastic(method = $lit)]
 // Parses #[elastic(method(expr = $expr))]
-fn get_method_from_struct(item: &syn::MacroInput, method: &str) -> Option<MethodFromStruct> {
+fn get_method_from_struct(item: &syn::DeriveInput, method: &str) -> Option<MethodFromStruct> {
     let val = get_elastic_meta_items(&item.attrs);
 
     // Attempt to get a literal
@@ -459,6 +466,7 @@ fn get_method_from_fields(
 
         // Return the expr value for `#[method(expr = expr)]`
         if let Some(expr) = val
+            .clone()
             .iter()
             .filter_map(|meta| expect_list(method, meta))
             .flat_map(|attrs| attrs)

--- a/src/elastic_derive/src/lib.rs
+++ b/src/elastic_derive/src/lib.rs
@@ -65,7 +65,7 @@ pub fn derive_date_format(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 }
 
 // Get the format string supplied by an #[elastic()] attribute
-fn get_crate_root<'a>(item: &'a syn::DeriveInput) -> Result<proc_macro2::TokenStream, String> {
+fn get_crate_root<'a>(item: &'a syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val
@@ -75,8 +75,8 @@ fn get_crate_root<'a>(item: &'a syn::DeriveInput) -> Result<proc_macro2::TokenSt
 
     match val {
         Some(crate_root) => {
-            // FIXME: do not hardcode the crate_root
-            Ok(quote!(crate::types).into())
+            let root = get_tokens_from_lit(&crate_root)?;
+            Ok(quote!(#root).into())
         }
         None => Ok(quote!(elastic::types).into()),
     }

--- a/src/elastic_derive/src/lib.rs
+++ b/src/elastic_derive/src/lib.rs
@@ -27,7 +27,20 @@ extern crate serde_json;
 extern crate chrono;
 
 use quote::TokenStreamExt;
-use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input,
+    spanned::Spanned,
+    Attribute,
+    DeriveInput,
+    Error as SynError,
+    Expr,
+    Ident,
+    Lit,
+    Meta,
+    MetaList,
+    MetaNameValue,
+    NestedMeta,
+};
 
 mod date_format;
 mod elastic_type;
@@ -35,7 +48,7 @@ mod elastic_type;
 #[proc_macro_derive(ElasticType, attributes(elastic))]
 pub fn derive_elastic_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut expanded = proc_macro2::TokenStream::new();
-    let ast: syn::DeriveInput = syn::parse_macro_input!(input);
+    let ast: DeriveInput = parse_macro_input!(input);
     let crate_root = get_crate_root(&ast).unwrap();
 
     match elastic_type::expand_derive(crate_root, &ast) {
@@ -51,7 +64,7 @@ pub fn derive_elastic_type(input: proc_macro::TokenStream) -> proc_macro::TokenS
 #[proc_macro_derive(ElasticDateFormat, attributes(elastic))]
 pub fn derive_date_format(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut expanded = proc_macro2::TokenStream::new();
-    let ast: syn::DeriveInput = syn::parse_macro_input!(input);
+    let ast: DeriveInput = parse_macro_input!(input);
     let crate_root = get_crate_root(&ast).unwrap();
 
     match date_format::expand_derive(crate_root, &ast) {
@@ -65,7 +78,7 @@ pub fn derive_date_format(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 }
 
 // Get the format string supplied by an #[elastic()] attribute
-fn get_crate_root<'a>(item: &'a syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+fn get_crate_root<'a>(item: &'a DeriveInput) -> Result<proc_macro2::TokenStream, SynError> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val
@@ -82,21 +95,18 @@ fn get_crate_root<'a>(item: &'a syn::DeriveInput) -> Result<proc_macro2::TokenSt
     }
 }
 
-fn get_elastic_meta_items<'a, I>(attrs: I) -> Vec<syn::NestedMeta>
+fn get_elastic_meta_items<'a, I>(attrs: I) -> Vec<NestedMeta>
 where
-    I: IntoIterator<Item = &'a syn::Attribute> + 'a,
+    I: IntoIterator<Item = &'a Attribute> + 'a,
 {
     attrs
         .into_iter()
         .filter_map(|attr| {
-            attr.parse_meta().ok().and_then(move |meta| match meta {
-                syn::Meta::List(syn::MetaList {
-                    ref path,
-                    ref nested,
-                    ..
-                }) if path.get_ident() == Some(&quote::format_ident!("{}", "elastic")) => {
-                    // TODO: get rid of `collect`
-                    Some(nested.iter().cloned().collect::<Vec<syn::NestedMeta>>())
+            attr.parse_meta().ok().and_then(|meta| match meta {
+                Meta::List(MetaList { ref path, ref nested, .. })
+                    if path.get_ident() == Some(&quote::format_ident!("{}", "elastic")) =>
+                {
+                    Some(nested.clone().into_iter())
                 }
                 _ => None,
             })
@@ -105,12 +115,10 @@ where
         .collect()
 }
 
-fn expect_name_value<'a>(name: &str, meta_item: &'a syn::NestedMeta) -> Option<&'a syn::Lit> {
+fn expect_name_value<'a>(name: &str, meta_item: &'a NestedMeta) -> Option<&'a Lit> {
     match *meta_item {
-        syn::NestedMeta::Meta(syn::Meta::NameValue(syn::MetaNameValue {
-            ref path,
-            ref lit,
-            ..
+        NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+            ref path, ref lit, ..
         })) if path.get_ident() == Some(&quote::format_ident!("{}", name)) => Some(lit),
         _ => None,
     }
@@ -118,10 +126,10 @@ fn expect_name_value<'a>(name: &str, meta_item: &'a syn::NestedMeta) -> Option<&
 
 fn expect_list<'a>(
     name: &str,
-    meta_item: &'a syn::NestedMeta,
-) -> Option<impl Iterator<Item = &'a syn::NestedMeta>> {
+    meta_item: &'a NestedMeta,
+) -> Option<impl Iterator<Item = &'a NestedMeta>> {
     match *meta_item {
-        syn::NestedMeta::Meta(syn::Meta::List(syn::MetaList {
+        NestedMeta::Meta(Meta::List(MetaList {
             ref path,
             ref nested,
             ..
@@ -130,33 +138,33 @@ fn expect_list<'a>(
     }
 }
 
-fn expect_ident<'a>(name: &str, meta_item: &'a syn::NestedMeta) -> bool {
+fn expect_ident<'a>(name: &str, meta_item: &'a NestedMeta) -> bool {
     let name = quote::format_ident!("{}", name);
     match *meta_item {
-        syn::NestedMeta::Meta(syn::Meta::Path(ref path)) if path.get_ident() == Some(&name) => true,
+        NestedMeta::Meta(Meta::Path(ref path)) if path.get_ident() == Some(&name) => true,
         _ => false,
     }
 }
 
-fn get_ident_from_lit(lit: &syn::Lit) -> Result<syn::Ident, &'static str> {
+fn get_ident_from_lit(lit: &Lit) -> Result<Ident, &'static str> {
     get_string_from_lit(lit).map(|s| proc_macro2::Ident::new(&s, proc_macro2::Span::call_site()))
 }
 
-fn get_tokens_from_lit<'a>(lit: &'a syn::Lit) -> Result<proc_macro2::TokenStream, syn::Error> {
-    if let syn::Lit::Str(ref s) = *lit {
-        let toks = s.parse::<syn::Expr>()?;
+fn get_tokens_from_lit<'a>(lit: &'a Lit) -> Result<proc_macro2::TokenStream, SynError> {
+    if let Lit::Str(ref s) = *lit {
+        let toks = s.parse::<Expr>()?;
         Ok(quote!(#toks))
     } else {
-        let err = syn::Error::new(lit.span(), "Unable to get TokenStream from syn::Lit");
+        let err = SynError::new(lit.span(), "Unable to get TokenStream from Lit");
         Err(err)
     }
 }
 
-fn get_string_from_lit<'a>(lit: &'a syn::Lit) -> Result<String, &'static str> {
+fn get_string_from_lit<'a>(lit: &'a Lit) -> Result<String, &'static str> {
     match *lit {
-        syn::Lit::Str(ref s) => Ok(s.value()),
+        Lit::Str(ref s) => Ok(s.value()),
         _ => {
-            return Err("Unable to get str from lit");
+            return Err("Unable to get String from Lit");
         }
     }
 }

--- a/src/elastic_derive/src/lib.rs
+++ b/src/elastic_derive/src/lib.rs
@@ -26,13 +26,15 @@ extern crate serde_json;
 
 extern crate chrono;
 
+use quote::TokenStreamExt;
+
 mod date_format;
 mod elastic_type;
 
 #[proc_macro_derive(ElasticType, attributes(elastic))]
 pub fn derive_elastic_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let mut expanded = quote::Tokens::new();
-    let ast = syn::parse_macro_input(&input.to_string()).unwrap();
+    let mut expanded = proc_macro2::TokenStream::new();
+    let ast: syn::DeriveInput = syn::parse_macro_input!(input);
     let crate_root = get_crate_root(&ast).unwrap();
 
     match elastic_type::expand_derive(crate_root, &ast) {
@@ -47,8 +49,8 @@ pub fn derive_elastic_type(input: proc_macro::TokenStream) -> proc_macro::TokenS
 
 #[proc_macro_derive(ElasticDateFormat, attributes(elastic))]
 pub fn derive_date_format(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let mut expanded = quote::Tokens::new();
-    let ast = syn::parse_macro_input(&input.to_string()).unwrap();
+    let mut expanded = proc_macro2::TokenStream::new();
+    let ast: syn::DeriveInput = syn::parse_macro_input!(input);
     let crate_root = get_crate_root(&ast).unwrap();
 
     match date_format::expand_derive(crate_root, &ast) {
@@ -62,7 +64,7 @@ pub fn derive_date_format(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 }
 
 // Get the format string supplied by an #[elastic()] attribute
-fn get_crate_root<'a>(item: &'a syn::MacroInput) -> Result<quote::Tokens, String> {
+fn get_crate_root<'a>(item: &'a syn::DeriveInput) -> Result<proc_macro2::TokenStream, String> {
     let val = get_elastic_meta_items(&item.attrs);
 
     let val = val
@@ -72,77 +74,80 @@ fn get_crate_root<'a>(item: &'a syn::MacroInput) -> Result<quote::Tokens, String
 
     match val {
         Some(crate_root) => {
-            let crate_root = get_str_from_lit(crate_root)?;
-
-            let mut tokens = quote::Tokens::new();
-            tokens.append(crate_root);
-
-            Ok(tokens)
+            // FIXME: do not hardcode the crate_root
+            Ok(quote!(crate::types).into())
         }
-        None => Ok(quote!(elastic::types)),
+        None => Ok(quote!(elastic::types).into()),
     }
 }
 
-fn get_elastic_meta_items<'a, I>(attrs: I) -> Vec<syn::NestedMetaItem>
+fn get_elastic_meta_items<'a, I>(attrs: I) -> Vec<syn::NestedMeta>
 where
     I: IntoIterator<Item = &'a syn::Attribute> + 'a,
 {
     attrs
         .into_iter()
-        .filter_map(|attr| match attr.value {
-            syn::MetaItem::List(ref key, ref list) if key == "elastic" => Some(list),
-            _ => None,
+        .filter_map(|attr| {
+            attr.parse_meta().ok().and_then(move |meta| match meta {
+                syn::Meta::List(syn::MetaList {
+                    ref path,
+                    ref nested,
+                    ..
+                }) if path.get_ident() == Some(&quote::format_ident!("{}", "elastic")) => {
+                    // TODO: get rid of `collect`
+                    Some(nested.iter().cloned().collect::<Vec<syn::NestedMeta>>())
+                }
+                _ => None,
+            })
         })
         .flat_map(|list| list)
-        .cloned()
         .collect()
 }
 
-fn expect_name_value<'a>(name: &str, meta_item: &'a syn::NestedMetaItem) -> Option<&'a syn::Lit> {
+fn expect_name_value<'a>(name: &str, meta_item: &'a syn::NestedMeta) -> Option<&'a syn::Lit> {
     match *meta_item {
-        syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref key, ref lit))
-            if key == name =>
-        {
-            Some(lit)
-        }
+        syn::NestedMeta::Meta(syn::Meta::NameValue(syn::MetaNameValue {
+            ref path,
+            ref lit,
+            ..
+        })) if path.get_ident() == Some(&quote::format_ident!("{}", name)) => Some(lit),
         _ => None,
     }
 }
 
 fn expect_list<'a>(
     name: &str,
-    meta_item: &'a syn::NestedMetaItem,
-) -> Option<&'a [syn::NestedMetaItem]> {
+    meta_item: &'a syn::NestedMeta,
+) -> Option<impl Iterator<Item = &'a syn::NestedMeta>> {
     match *meta_item {
-        syn::NestedMetaItem::MetaItem(syn::MetaItem::List(ref key, ref list)) if key == name => {
-            Some(list)
-        }
+        syn::NestedMeta::Meta(syn::Meta::List(syn::MetaList {
+            ref path,
+            ref nested,
+            ..
+        })) if path.get_ident() == Some(&quote::format_ident!("{}", name)) => Some(nested.iter()),
         _ => None,
     }
 }
 
-fn expect_ident<'a>(name: &str, meta_item: &'a syn::NestedMetaItem) -> bool {
+fn expect_ident<'a>(name: &str, meta_item: &'a syn::NestedMeta) -> bool {
+    let name = quote::format_ident!("{}", name);
     match *meta_item {
-        syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref ident)) if ident == name => true,
+        syn::NestedMeta::Meta(syn::Meta::Path(ref path)) if path.get_ident() == Some(&name) => true,
         _ => false,
     }
 }
 
 fn get_ident_from_lit(lit: &syn::Lit) -> Result<syn::Ident, &'static str> {
-    get_str_from_lit(lit).map(Into::into)
+    get_string_from_lit(lit).map(|s| proc_macro2::Ident::new(&s, proc_macro2::Span::call_site()))
 }
 
-fn get_tokens_from_lit<'a>(lit: &'a syn::Lit) -> Result<quote::Tokens, &'static str> {
-    get_str_from_lit(lit).map(|s| {
-        let mut tokens = quote::Tokens::new();
-        tokens.append(s);
-        tokens
-    })
+fn get_tokens_from_lit<'a>(lit: &'a syn::Lit) -> Result<proc_macro2::TokenStream, &'static str> {
+    get_string_from_lit(lit).map(|s| quote!(#s))
 }
 
-fn get_str_from_lit<'a>(lit: &'a syn::Lit) -> Result<&'a str, &'static str> {
+fn get_string_from_lit<'a>(lit: &'a syn::Lit) -> Result<String, &'static str> {
     match *lit {
-        syn::Lit::Str(ref s, _) => Ok(s.as_str()),
+        syn::Lit::Str(ref s) => Ok(s.value()),
         _ => {
             return Err("Unable to get str from lit");
         }


### PR DESCRIPTION
This is *almost* complete (albeit a little hacky), ant it passes all tests except one. 

I am not sure why [this](https://github.com/elastic-rs/elastic/blob/0f90521cf03304f2bfa870a8511d8cfc4f69d18f/tests/derive_compile_test/src/main.rs#L27) test method and [this](https://github.com/elastic-rs/elastic/blob/0f90521cf03304f2bfa870a8511d8cfc4f69d18f/tests/derive_compile_test/src/main.rs#L47) test method are not being used anymore...