### PR TITLE
Update nom dependency

### DIFF
--- a/src/elastic_derive/Cargo.toml
+++ b/src/elastic_derive/Cargo.toml
@@ -17,5 +17,5 @@ syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
 quote = "~0.3.0"
 serde_derive_internals = { version = "~0.15.0", default-features = false }
 quick-error = "~1"
-nom = "~3"
+nom = "~5"
 chrono = { version = "~0.4.0", features = [ "serde" ]}

--- a/src/elastic_derive/Cargo.toml
+++ b/src/elastic_derive/Cargo.toml
@@ -17,5 +17,5 @@ syn = { version = "~0.11.0", features = ["aster", "visit", "parsing", "full"] }
 quote = "~0.3.0"
 serde_derive_internals = { version = "~0.15.0", default-features = false }
 quick-error = "~1"
-nom = "~5"
+nom = { version = "~5", default-features = false, features = ["std"] }
 chrono = { version = "~0.4.0", features = [ "serde" ]}

--- a/src/elastic_derive/src/lib.rs
+++ b/src/elastic_derive/src/lib.rs
@@ -17,7 +17,6 @@ extern crate syn;
 #[macro_use]
 extern crate quick_error;
 
-#[macro_use]
 extern crate nom;
 
 extern crate serde;


### PR DESCRIPTION
All `elastic_derive` tests pass, *but*:

No idea what is going on but if you run `cargo test` from the root of the repo you get a linking error but if you run `cargo build` from the root of the repo it works...

If you run `cargo test` from *any* of the workspace member's directories everything works...

I have tried:
- `rustc 1.39.0-nightly (72b2abfd6 2019-08-29)`
- ` rustc 1.37.0 (eae3437df 2019-08-13)` 

each targeting: `x86_64-apple-darwin` and `x86_64-unknown-linux-musl`.

Here is the error message:
```
   Compiling elastic_derive v0.21.0-pre.5 (/Users/wm/Developer/elastic/src/elastic_derive)
warning: unused `#[macro_use]` import
  --> src/elastic_derive/src/lib.rs:20:1
   |
20 | #[macro_use]
   | ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused `#[macro_use]` import
  --> src/elastic_derive/src/lib.rs:20:1
   |
20 | #[macro_use]
   | ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

   Compiling reqwest v0.9.20
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-m64" "-L" "/Users/wm/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.16dje5vtmf4ilqa8.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.1aw49vqupy2qhj4a.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.1tvv4678du75a1fz.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.1wtspyhskms5prmd.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.209eikzldqi5vmjp.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.20d47w5yzhxxco79.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.20e1agyptcs82vfm.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2230fegdkw1z96he.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.223u7cxmpj25txkh.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2861jqa3lfqilglm.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2d6jh4ix8d38qhga.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2e94a1vic1f5xvt4.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2g5pbxnqgcdf4p8x.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2h6rbcdc7cm858oj.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2n7c40noh512auh0.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2piglza8lgg3qwvb.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2rfs06kb47pir0ne.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2y5hskog82q6xm8y.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.2yu091cc0tb4ho7n.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.34x2tm5vl2mvy6cd.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.35xnnd4mvbrzd1yt.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3966u8emrwtjlrwq.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3c4r8h1feg1nlisn.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3fucgz5ufsytzzeq.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3j0ehbvuabo3da2f.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3o6k4hzqjg8ejr6d.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3q8g2l0oog4twgmr.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3qwehaki128u3d0j.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3rstnlkp86qvtyli.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3sbaupesxisj4ml1.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3t4938nidguongli.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3ta8o699x4737zuz.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.3tflkittcy0ifj9o.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.40c6mizxpt0xdlkb.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.423arjaiwpnpdeop.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.4793o75nw0fnor8v.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.4doql4bek9r4r1ug.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.4i3r73d749pwhj24.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.4q63mac98vb7fb3x.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.568h93mtmpvylhnw.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.5eyga3jn3se1byyu.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.91cnzcxtreklf61.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.dsm9ilod8500a1w.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.erkt2gr6oy773lw.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.k60tkcpfg8j74yn.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.lc8ph6wpophl8mm.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.qlmbpr9tcp3j94l.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.rbevr4edozbdx7b.rcgu.o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33.ynw5w13u11bvr26.rcgu.o" "-o" "/Users/wm/Developer/elastic/target/debug/deps/elastic_derive-009b8534e7ef2e33" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/wm/Developer/elastic/target/debug/deps" "-L" "/Users/wm/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "-L" "/Users/wm/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "-ltest-c9b9af0c67573068" "/Users/wm/Developer/elastic/target/debug/deps/libchrono-e0605e59cf482638.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libnum_integer-4a320ec07da27a2e.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libnum_traits-03be4e89c368108e.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libtime-b8f5f26cb29f8228.rlib" "/Users/wm/Developer/elastic/target/debug/deps/liblibc-7eaa5514c0682c52.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libserde_json-7c71c4cc5487544f.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libitoa-cfbc258a616f87e5.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libserde_derive_internals-56fa606bb09ddd1a.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libserde-55779db5cb2c97ae.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libnom-47a89e36baa632ef.rlib" "-L" "/Users/wm/Developer/elastic/target/debug/deps" "-llexical_core-d05e2aaca1c4c6fb" "/Users/wm/Developer/elastic/target/debug/deps/libryu-8c546781ed26100c.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libarrayvec-7ce5ab187da71e8d.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libnodrop-5fdfbea57f1572d1.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libstatic_assertions-fb22529def4f7420.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libcfg_if-de5a4a5ac99d5e72.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libmemchr-e3945f6a1c4bfb19.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libquick_error-89e7c2ac87fc997c.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libsyn-56bde269fa816459.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libsynom-7d3c4585cf9203b2.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libunicode_xid-c63be281c8ea1265.rlib" "/Users/wm/Developer/elastic/target/debug/deps/libquote-026a97e33ba1d6e9.rlib" "/Users/wm/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libproc_macro-34e4a01d4569a5d7.rlib" "-L" "/Users/wm/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "-lstd-af052a57fa360059" "/Users/wm/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-cbdf5472a1ceaccf.rlib" "-lSystem" "-lresolv" "-lc" "-lm"
  = note: Undefined symbols for architecture x86_64:
            "_$LT$core..ops..range..Range$LT$usize$GT$$u20$as$u20$core..slice..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$::index::h8e5496247852d0d6", referenced from:
                _$LT$core..ops..range..RangeTo$LT$usize$GT$$u20$as$u20$core..slice..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$::index::h52fdf7efe76966c7 in libnom-47a89e36baa632ef.rlib(nom-47a89e36baa632ef.nom.3em15ov0-cgu.10.rcgu.o)
            "core::slice::_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$::index::h131e4fc08e872067", referenced from:
                core::slice::_$LT$impl$u20$$u5b$T$u5d$$GT$::split_at::hc82f33c22adfbe80 in libnom-47a89e36baa632ef.rlib(nom-47a89e36baa632ef.nom.3em15ov0-cgu.5.rcgu.o)
            "_$LT$$RF$T$u20$as$u20$core..fmt..Debug$GT$::fmt::he72aa5d1e7dd9435", referenced from:
                l_anon.9526f0c4f6fb87572be7558440a1a757.5 in libnom-47a89e36baa632ef.rlib(nom-47a89e36baa632ef.nom.3em15ov0-cgu.8.rcgu.o)
            "core::ptr::_$LT$impl$u20$$BP$mut$u20$T$GT$::is_null::h5cad4bbfc500c1c8", referenced from:
                core::ptr::non_null::NonNull$LT$T$GT$::new::h85336a68eb359198 in libnom-47a89e36baa632ef.rlib(nom-47a89e36baa632ef.nom.3em15ov0-cgu.8.rcgu.o)
            "core::cmp::Ord::max::h407ce36e51abb1bb", referenced from:
                core::cmp::max::hd2a95550f37c1d72 in libnom-47a89e36baa632ef.rlib(nom-47a89e36baa632ef.nom.3em15ov0-cgu.11.rcgu.o)
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```