### PR TITLE
Bulk api fixes

### DIFF
--- a/src/elastic/src/client/requests/bulk/operation.rs
+++ b/src/elastic/src/client/requests/bulk/operation.rs
@@ -79,7 +79,7 @@ impl<TParams> BulkOperation<Script<TParams>> {
         builder: TBuilder,
     ) -> BulkOperation<Script<TNewParams>>
     where
-        TBuilder: Fn(ScriptBuilder<TParams>) -> ScriptBuilder<TNewParams>,
+        TBuilder: FnOnce(ScriptBuilder<TParams>) -> ScriptBuilder<TNewParams>,
     {
         let inner = self
             .inner
@@ -280,7 +280,7 @@ where
     where
         TId: Into<Id<'static>>,
         TScript: ToString,
-        TBuilder: Fn(ScriptBuilder<DefaultParams>) -> ScriptBuilder<TParams>,
+        TBuilder: FnOnce(ScriptBuilder<DefaultParams>) -> ScriptBuilder<TParams>,
     {
         BulkOperation {
             action: Action::Update,
@@ -411,7 +411,7 @@ impl BulkRawOperation {
     ) -> BulkOperation<Script<TParams>>
     where
         TScript: ToString,
-        TBuilder: Fn(ScriptBuilder<DefaultParams>) -> ScriptBuilder<TParams>,
+        TBuilder: FnOnce(ScriptBuilder<DefaultParams>) -> ScriptBuilder<TParams>,
     {
         BulkOperation {
             action: Action::Update,

--- a/src/elastic/src/client/requests/bulk/operation.rs
+++ b/src/elastic/src/client/requests/bulk/operation.rs
@@ -404,7 +404,7 @@ impl BulkRawOperation {
     /**
     Update the bulk operation script.
     */
-    pub fn update_script_fluent<TId, TScript, TBuilder, TParams>(
+    pub fn update_script_fluent<TScript, TBuilder, TParams>(
         self,
         script: TScript,
         builder: TBuilder,

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -543,7 +543,7 @@ where
     pub fn script_fluent<TScript, TParams>(
         self,
         source: TScript,
-        builder: impl Fn(ScriptBuilder<DefaultParams>) -> ScriptBuilder<TParams>,
+        builder: impl FnOnce(ScriptBuilder<DefaultParams>) -> ScriptBuilder<TParams>,
     ) -> UpdateRequestBuilder<TSender, Script<TParams>>
     where
         TScript: ToString,


### PR DESCRIPTION
Fixed two issues with some bulk APIs

* A few functions took `Fn` when they could be taking `FnOnce`.
* Remove unused TId type parameter from BulkRawOperation::update_script_fluent