### PR TITLE
Add (default) geo-types feature

### DIFF
--- a/src/elastic/Cargo.toml
+++ b/src/elastic/Cargo.toml
@@ -15,12 +15,22 @@ travis-ci = { repository = "elastic-rs/elastic" }
 appveyor = { repository = "elastic-rs/elastic" }
 
 [features]
+default = [
+    "geo-types"
+]
+
 rustls-tls = [
     "reqwest/rustls-tls"
 ]
 
 default-tls = [
     "reqwest/default-tls"
+]
+
+geo-types = [
+    "geo",
+    "geohash",
+    "geojson"
 ]
 
 [dependencies]
@@ -43,9 +53,9 @@ tokio-threadpool = "~0.1"
 fluent_builder = "~0.6"
 crossbeam-channel = "~0.3"
 chrono = { version = "~0.4.0", features = [ "serde" ]}
-geo = "~0.12.0"
-geohash = "~0.9.0"
-geojson = "~0.16.0"
+geo = { version = "~0.12.0", optional = true }
+geohash = { version = "~0.9.0", optional = true }
+geojson = { version = "~0.16.0", optional = true }
 
 [dev-dependencies]
 env_logger = "~0.6"

--- a/src/elastic/src/types/geo/mod.rs
+++ b/src/elastic/src/types/geo/mod.rs
@@ -1,9 +1,11 @@
 /*!
-Implementation of the Elasticsearch `geo` types.
+Implementation of the Elasticsearch `geo` types.[^geo]
 
 Use [`point::GeoPoint`](point/struct.GeoPoint.html) for indexing simple geo points with an `x` and `y` coordinate.
 
 Use [`shape::GeoShape`](shape/struct.GeoShape.html) for indexing `geojson`.
+
+[^geo]: requires building with the `geo-types` feature (which is enabled by default)
 */
 
 pub mod mapping;

--- a/src/elastic/src/types/mod.rs
+++ b/src/elastic/src/types/mod.rs
@@ -49,8 +49,10 @@ The following table illustrates the types provided by `elastic`:
  `boolean`           | `bool`                      | `std`     | [`Boolean<M>`][boolean-mod]                              | -
  `ip`                | `Ipv4Addr`                  | `std`     | [`Ip<M>`][ip-mod]                                        | -
  `date`              | `DateTime<UTC>`             | `chrono`  | [`Date<M>`][date-mod]                                    | `DateFormat`
- `geo_point`         | `Point`                     | `geo`     | [`GeoPoint<M>`][geopoint-mod]                            | `GeoPointFormat`
- `geo_shape`         | -                           | `geojson` | [`GeoShape<M>`][geoshape-mod]                            | -
+ `geo_point`[^geo]   | `Point`                     | `geo`     | [`GeoPoint<M>`][geopoint-mod]                            | `GeoPointFormat`
+ `geo_shape`[^geo]   | -                           | `geojson` | [`GeoShape<M>`][geoshape-mod]                            | -
+
+[^geo]: requires building with the `geo-types` feature (which is enabled by default)
 
 ## Mapping
 
@@ -248,6 +250,7 @@ mod private;
 pub mod boolean;
 pub mod date;
 pub mod document;
+#[cfg(features = "geo-types")]
 pub mod geo;
 pub mod ip;
 pub mod number;
@@ -268,9 +271,11 @@ pub mod prelude {
     pub use super::{
         boolean::prelude::*,
         date::prelude::*,
-        geo::prelude::*,
         ip::prelude::*,
         number::prelude::*,
         string::prelude::*,
     };
+
+    #[cfg(features = "geo-types")]
+    pub use geo::prelude::*;
 }


### PR DESCRIPTION
@KodrAus, you cool with this? 

- Should I put `chrono` behind a (default) feature before merging this?
- Should I separate them into two features - `geo-shape` and `geo-shape` or is that too much?