### PR TITLE
Refactor into common Pending type

### DIFF
--- a/src/elastic/src/client/requests/bulk/mod.rs
+++ b/src/elastic/src/client/requests/bulk/mod.rs
@@ -11,10 +11,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use serde::{
     de::DeserializeOwned,
     ser::Serialize,
@@ -23,6 +20,7 @@ use serde::{
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -798,29 +796,7 @@ impl BulkBody for Vec<u8> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending<TResponse> {
-    inner: Box<dyn Future<Item = TResponse, Error = Error> + Send>,
-}
-
-impl<TResponse> Pending<TResponse> {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = TResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl<TResponse> Future for Pending<TResponse> {
-    type Item = TResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending<TResponse> = BasePending<TResponse>;
 
 #[doc(hidden)]
 pub trait ChangeIndex<TIndex> {

--- a/src/elastic/src/client/requests/document_delete.rs
+++ b/src/elastic/src/client/requests/document_delete.rs
@@ -4,15 +4,13 @@ Builders for [delete document requests][docs-delete].
 [docs-delete]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use std::marker::PhantomData;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -314,29 +312,7 @@ impl<TDocument> DeleteRequestBuilder<AsyncSender, TDocument> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = DeleteResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = DeleteResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = DeleteResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<DeleteResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/document_get.rs
+++ b/src/elastic/src/client/requests/document_get.rs
@@ -4,16 +4,14 @@ Builders for [get document requests][docs-get].
 [docs-get]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -320,32 +318,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending<TDocument> {
-    inner: Box<dyn Future<Item = GetResponse<TDocument>, Error = Error> + Send>,
-}
-
-impl<TDocument> Pending<TDocument> {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = GetResponse<TDocument>, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl<TDocument> Future for Pending<TDocument>
-where
-    TDocument: DeserializeOwned + Send + 'static,
-{
-    type Item = GetResponse<TDocument>;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending<TDocument> = BasePending<GetResponse<TDocument>>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/document_index.rs
+++ b/src/elastic/src/client/requests/document_index.rs
@@ -4,16 +4,14 @@ Builders for [index requests][docs-index].
 [docs-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use serde::Serialize;
 use serde_json;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -369,29 +367,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = IndexResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = IndexResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = IndexResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<IndexResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/document_put_mapping.rs
+++ b/src/elastic/src/client/requests/document_put_mapping.rs
@@ -4,16 +4,14 @@ Builders for [put mapping requests][docs-mapping].
 [docs-mapping]: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use serde_json;
 use std::marker::PhantomData;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -269,29 +267,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = CommandResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = CommandResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<CommandResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/document_update.rs
+++ b/src/elastic/src/client/requests/document_update.rs
@@ -4,10 +4,7 @@ Builders for [update document requests][docs-update].
 [docs-update]: http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use serde::ser::Serialize;
 use serde_json;
 use std::marker::PhantomData;
@@ -15,6 +12,7 @@ use std::marker::PhantomData;
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -672,29 +670,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = UpdateResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = UpdateResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = UpdateResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<UpdateResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/index_close.rs
+++ b/src/elastic/src/client/requests/index_close.rs
@@ -4,14 +4,12 @@ Builders for [close index requests][docs-close-index].
 [docs-close-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -178,29 +176,7 @@ impl IndexCloseRequestBuilder<AsyncSender> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = CommandResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = CommandResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<CommandResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/index_create.rs
+++ b/src/elastic/src/client/requests/index_create.rs
@@ -4,14 +4,12 @@ Builders for [create index requests][docs-create-index].
 [docs-create-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -263,29 +261,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = CommandResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = CommandResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<CommandResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/index_delete.rs
+++ b/src/elastic/src/client/requests/index_delete.rs
@@ -4,14 +4,12 @@ Builders for [delete index requests][docs-delete-index].
 [docs-delete-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -174,29 +172,7 @@ impl IndexDeleteRequestBuilder<AsyncSender> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = CommandResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = CommandResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<CommandResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/index_exists.rs
+++ b/src/elastic/src/client/requests/index_exists.rs
@@ -4,14 +4,12 @@ Builders for [index exists requests][docs-index-exists].
 [docs-index-exists]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -174,29 +172,7 @@ impl IndexExistsRequestBuilder<AsyncSender> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = IndicesExistsResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = IndicesExistsResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = IndicesExistsResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<IndicesExistsResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/index_open.rs
+++ b/src/elastic/src/client/requests/index_open.rs
@@ -4,14 +4,12 @@ Builders for [open index requests][docs-open-index].
 [docs-open-index]: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -178,29 +176,7 @@ impl IndexOpenRequestBuilder<AsyncSender> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = CommandResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = CommandResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = CommandResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<CommandResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/ping.rs
+++ b/src/elastic/src/client/requests/ping.rs
@@ -2,14 +2,12 @@
 Builders for ping requests.
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -181,29 +179,7 @@ impl PingRequestBuilder<AsyncSender> {
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = PingResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = PingResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = PingResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<PingResponse>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/search.rs
+++ b/src/elastic/src/client/requests/search.rs
@@ -4,16 +4,14 @@ Builders for [search requests][docs-search].
 [docs-search]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -413,32 +411,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending<TDocument> {
-    inner: Box<dyn Future<Item = SearchResponse<TDocument>, Error = Error> + Send>,
-}
-
-impl<TDocument> Pending<TDocument> {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = SearchResponse<TDocument>, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl<TDocument> Future for Pending<TDocument>
-where
-    TDocument: DeserializeOwned + Send + 'static,
-{
-    type Item = SearchResponse<TDocument>;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending<TDocument> = BasePending<SearchResponse<TDocument>>;
 
 #[cfg(test)]
 mod tests {

--- a/src/elastic/src/client/requests/sql.rs
+++ b/src/elastic/src/client/requests/sql.rs
@@ -4,14 +4,12 @@ Builders for [sql queries][sql].
 [sql]: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest.html
 */
 
-use futures::{
-    Future,
-    Poll,
-};
+use futures::Future;
 
 use crate::{
     client::{
         requests::{
+            Pending as BasePending,
             raw::RawRequestInner,
             RequestBuilder,
         },
@@ -294,29 +292,7 @@ where
 }
 
 /** A future returned by calling `send`. */
-pub struct Pending {
-    inner: Box<dyn Future<Item = SqlQueryResponse, Error = Error> + Send>,
-}
-
-impl Pending {
-    fn new<F>(fut: F) -> Self
-    where
-        F: Future<Item = SqlQueryResponse, Error = Error> + Send + 'static,
-    {
-        Pending {
-            inner: Box::new(fut),
-        }
-    }
-}
-
-impl Future for Pending {
-    type Item = SqlQueryResponse;
-    type Error = Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll()
-    }
-}
+pub type Pending = BasePending<SqlQueryResponse>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Almost every module in client::requests defines their own Pending struct,
wrapping a Boxed future, using copy+pasted code. This patch implements a
templated Pending type in the client::requests module, and uses it in submodules.

The patch also sets up a type alias called Pending in each of the submodules,
to retain backwards compatibility.


This is also laying some groundwork for opening up `Sender` to different implementations, where the `Pending` type may be a generic instead.