### PR TITLE
Add `sort` to `Hit`.

### DIFF
--- a/src/elastic/src/client/responses/search.rs
+++ b/src/elastic/src/client/responses/search.rs
@@ -264,6 +264,7 @@ pub struct Hit<T> {
     #[serde(rename = "_routing")]
     routing: Option<String>,
     highlight: Option<Value>,
+    sort: Option<Value>,
 }
 
 impl<T> Hit<T> {
@@ -310,6 +311,13 @@ impl<T> Hit<T> {
     */
     pub fn highlight(&self) -> Option<&Value> {
         self.highlight.as_ref()
+    }
+
+    /**
+    A reference to the sort value of the hit, if the query was sorted by something else other than score.
+    */
+    pub fn sort(&self) -> Option<&Value> {
+        self.sort.as_ref()
     }
 }
 


### PR DESCRIPTION
If you specify sort in an elasticsearch query, you'll get back a field called `sort` with the value that used for sorting that specific hit---this is sueful if you do any kind of fancy sorting or if passing `_source=False` but still want to paginate e.g. id-s.

Let me know if there's any kind of convention I've not adhered to, first time contributing to this repo.

On a related note---is there any reason why `Hit` doesn't have all public fields? I wanted to extract `id` and `sort` from my hits, and I currently have to clone to do that, even if I use `into_hits`. If `Id`, `Index`, `Type` derived `Deserialize`, they could be used as member types, removing the need for the conversion performed by the corresponding accessors.

Thanks a lot for this library! Using it over the official one for a couple of reason, but a big one is the presence of a `SyncClient`.